### PR TITLE
Feature/definition factory

### DIFF
--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1,4 +1,4 @@
-use crate::dag_checker::{check_contains_cycle, find_sink_nodes, find_source_nodes};
+use crate::dag_checker::{check_contains_cycle, find_source_nodes};
 use crate::errors::YoshiError;
 use crate::runners::MessageFromRunner::{Done, Failure};
 use crate::runners::TaskRunnerFactory;

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -148,7 +148,7 @@ impl Dag {
         if self.start_nodes.is_empty() {
             return Err(YoshiError {
                 message: "Dag cannot start without source node".to_string(),
-                origin: "Dag.run".to_string()
+                origin: "Dag.run".to_string(),
             });
         }
         let mut bag_of_nodes = self.start_nodes.clone();

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -147,8 +147,8 @@ impl Dag {
         info!("Starting dag");
         if self.start_nodes.is_empty() {
             return Err(YoshiError {
-                message: format!("Dag cannot start without source node"),
-                origin: format!("Dag.run"),
+                message: "Dag cannot start without source node".to_string(),
+                origin: "Dag.run".to_string()
             });
         }
         let mut bag_of_nodes = self.start_nodes.clone();

--- a/src/dag_checker.rs
+++ b/src/dag_checker.rs
@@ -1,7 +1,7 @@
 use crate::dag::Dag;
 use crate::errors::YoshiError;
 use crate::type_definition::NodeId;
-use log::{debug, info};
+use log::{info};
 use petgraph::algo::is_cyclic_directed;
 use petgraph::Direction;
 

--- a/src/dag_checker.rs
+++ b/src/dag_checker.rs
@@ -1,7 +1,7 @@
 use crate::dag::Dag;
 use crate::errors::YoshiError;
 use crate::type_definition::NodeId;
-use log::{info};
+use log::info;
 use petgraph::algo::is_cyclic_directed;
 use petgraph::Direction;
 

--- a/src/dag_checker_test.rs
+++ b/src/dag_checker_test.rs
@@ -2,7 +2,7 @@ use crate::dag::Dag;
 use crate::dag_checker::{check_contains_cycle, find_sink_nodes, find_source_nodes};
 use crate::task_definition::DummyTaskDefinition;
 use crate::task_node::TaskNode;
-use crate::type_definition::{NodeId, RunnerId};
+use crate::type_definition::RunnerId;
 
 /*
 #[test]

--- a/src/dag_parsing/dag_config.rs
+++ b/src/dag_parsing/dag_config.rs
@@ -116,7 +116,7 @@ impl From<DagConfig> for Dag {
                     let args_string = def_cfg.params.get("args").unwrap();
                     let mut args: Vec<String> = vec![];
                     if args_string.to_string() == "[]".to_string() {
-                        let args = vec![];
+                        let args: Vec<String> = vec![];
                     } else {
                         let args = vec![args_string.to_string()];
                     }

--- a/src/dag_parsing/dag_config.rs
+++ b/src/dag_parsing/dag_config.rs
@@ -116,9 +116,9 @@ impl From<DagConfig> for Dag {
                     let args_string = def_cfg.params.get("args").unwrap();
                     let mut args: Vec<String> = vec![];
                     if args_string.to_string() == "[]".to_string() {
-                        args = vec![];
+                        let args = vec![];
                     } else {
-                        args = vec![args_string.to_string()];
+                        let args = vec![args_string.to_string()];
                     }
                     definition =
                         Box::new(PythonTaskDefinition::new(FilePath::from(script_path), args));

--- a/src/dag_parsing/dag_config_test.rs
+++ b/src/dag_parsing/dag_config_test.rs
@@ -4,12 +4,9 @@ use crate::dag_parsing::dag_config_parser::DagConfigParser;
 use crate::dag_parsing::get_dag_from_file;
 use crate::dag_parsing::YamlDagConfigParser;
 use crate::runners::TaskRunnerType;
-use crate::task_definition::{
-    BashTaskDefinition, DummyTaskDefinition, PythonTaskDefinition, TaskDefinitionType,
-};
-use crate::task_node::TaskNode;
+use crate::task_definition::TaskDefinitionType;
 use crate::type_definition::{FilePath, NodeId};
-use log::{debug, info};
+use log::info;
 use std::collections::HashMap;
 use std::fs;
 
@@ -88,8 +85,8 @@ fn it_can_take_config_to_dag() {
         TaskDefinitionType::Python
     );
     assert_eq!(nodeA_node.id_runner, TaskRunnerType::LocalBlocking);
-    let neighbors_A: Vec<NodeId> = result_dag.graph_nodes.neighbors(*nodeA_id).collect();
-    assert_eq!(neighbors_A, vec![dummy_end_id.clone()]);
+    let neighbors_a: Vec<NodeId> = result_dag.graph_nodes.neighbors(*nodeA_id).collect();
+    assert_eq!(neighbors_a, vec![dummy_end_id.clone()]);
 
     // todo: add nodeB
     // todo: check definition params

--- a/src/dag_test.rs
+++ b/src/dag_test.rs
@@ -1,5 +1,5 @@
 use crate::dag::Dag;
-use crate::runners::{FakeTaskRunner, TaskRunnerType};
+use crate::runners::TaskRunnerType;
 use crate::task_definition::{generate_task_definition_id, BashTaskDefinition};
 use crate::task_node::TaskNode;
 

--- a/src/runners/runner_factory_test.rs
+++ b/src/runners/runner_factory_test.rs
@@ -1,4 +1,4 @@
-use crate::runners::{FakeTaskRunner, TaskRunnerFactory, TaskRunnerType};
+use crate::runners::{TaskRunnerFactory, TaskRunnerType};
 
 #[test]
 fn it_can_return_a_runner() {

--- a/src/task_definition/bash_task.rs
+++ b/src/task_definition/bash_task.rs
@@ -1,10 +1,7 @@
 use crate::errors::YoshiError;
 use crate::task_definition::{
-    generate_task_definition_id, 
-    TaskDefinition, 
-    TaskDefinitionType, 
-    DefinitionArguments,
-    DefinitionArgumentElement
+    generate_task_definition_id, DefinitionArgumentElement, DefinitionArguments, TaskDefinition,
+    TaskDefinitionType,
 };
 use crate::task_output::TaskOutput;
 use crate::type_definition::TaskId;
@@ -24,9 +21,7 @@ impl From<DefinitionArguments> for BashTaskDefinition {
     fn from(da: DefinitionArguments) -> Self {
         if let Some(e) = da.get(&"command".to_string()) {
             match e {
-                DefinitionArgumentElement::VecString(vs) => {
-                    BashTaskDefinition::new(vs)
-                },
+                DefinitionArgumentElement::VecString(vs) => BashTaskDefinition::new(vs),
                 _ => {
                     panic!("Trying to create BashTask with something other than String");
                 }

--- a/src/task_definition/bash_task.rs
+++ b/src/task_definition/bash_task.rs
@@ -1,5 +1,5 @@
 use crate::errors::YoshiError;
-use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType};
+use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType, DefinitionArguments};
 use crate::task_output::TaskOutput;
 use crate::type_definition::TaskId;
 use log::{debug, error, info};
@@ -12,6 +12,14 @@ use std::str;
 pub struct BashTaskDefinition {
     task_def_id: TaskId,
     command: Vec<String>,
+}
+
+impl From<DefinitionArguments> for BashTaskDefinition {
+    fn from(da: DefinitionArguments) -> Self {
+        let command = da.get("command");
+        let vec_command = vec![command];  // todo: make correctly
+        BashTaskDefinition::new(vec_command)
+    }
 }
 
 impl TaskDefinition for BashTaskDefinition {

--- a/src/task_definition/bash_task.rs
+++ b/src/task_definition/bash_task.rs
@@ -1,5 +1,11 @@
 use crate::errors::YoshiError;
-use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType, DefinitionArguments};
+use crate::task_definition::{
+    generate_task_definition_id, 
+    TaskDefinition, 
+    TaskDefinitionType, 
+    DefinitionArguments,
+    DefinitionArgumentElement
+};
 use crate::task_output::TaskOutput;
 use crate::type_definition::TaskId;
 use log::{debug, error, info};
@@ -16,9 +22,18 @@ pub struct BashTaskDefinition {
 
 impl From<DefinitionArguments> for BashTaskDefinition {
     fn from(da: DefinitionArguments) -> Self {
-        let command = da.get("command");
-        let vec_command = vec![command];  // todo: make correctly
-        BashTaskDefinition::new(vec_command)
+        if let Some(e) = da.get(&"command".to_string()) {
+            match e {
+                DefinitionArgumentElement::VecString(vs) => {
+                    BashTaskDefinition::new(vs)
+                },
+                _ => {
+                    panic!("Trying to create BashTask with something other than String");
+                }
+            }
+        } else {
+            panic!("Could not find parameter 'command' to create BashTask");
+        }
     }
 }
 

--- a/src/task_definition/definition_arguments.rs
+++ b/src/task_definition/definition_arguments.rs
@@ -1,16 +1,15 @@
 use crate::type_definition::FilePath;
 use std::collections::HashMap;
 
-
 // todo: move to new module
 // todo: review visibility
 #[derive(Debug, Clone, Copy)]
 pub enum DefinitionArgumentType {
-    AString,  // A-string to differentiate from type
+    AString, // A-string to differentiate from type
     Filepath,
     Integer,
     Float,
-    VecString
+    VecString,
 }
 
 #[derive(Debug, PartialEq)]
@@ -20,11 +19,11 @@ pub enum DefinitionArgumentElement {
     Integer(i64),
     Float(f64),
     /// Vec of string as JSON array
-    VecString(Vec<String>)
+    VecString(Vec<String>),
 }
 
 pub struct DefinitionArguments {
-    map: HashMap<String, (String, DefinitionArgumentType)>
+    map: HashMap<String, (String, DefinitionArgumentType)>,
 }
 
 // todo: temporary, use a library or something more efficient and fail-proff
@@ -33,7 +32,7 @@ fn string_to_vec_of_string(mut s: String) -> Vec<String> {
     s.remove(0);
     s.remove(s.len() - 1);
     if s.is_empty() {
-        return res
+        return res;
     }
     // basic iterative algo
     let mut opened_quotes = false;
@@ -62,7 +61,7 @@ fn string_to_vec_of_string(mut s: String) -> Vec<String> {
 impl DefinitionArguments {
     pub fn new() -> Self {
         DefinitionArguments {
-            map: HashMap::new()
+            map: HashMap::new(),
         }
     }
 
@@ -77,32 +76,31 @@ impl DefinitionArguments {
                 match t {
                     DefinitionArgumentType::AString => {
                         Some(DefinitionArgumentElement::AString(value))
-                    },
+                    }
                     DefinitionArgumentType::Filepath => {
                         let fp = FilePath::from(value);
                         Some(DefinitionArgumentElement::Filepath(fp))
-                    },
+                    }
                     DefinitionArgumentType::Integer => {
                         let as_int = value.parse::<i64>().unwrap();
                         Some(DefinitionArgumentElement::Integer(as_int))
-                    },
+                    }
                     DefinitionArgumentType::Float => {
                         let as_float = value.parse::<f64>().unwrap();
                         Some(DefinitionArgumentElement::Float(as_float))
-                    },
+                    }
                     DefinitionArgumentType::VecString => {
                         // from JSON format
                         // todo: use a library (serde?)
-                        let result = string_to_vec_of_string(value);               
+                        let result = string_to_vec_of_string(value);
                         Some(DefinitionArgumentElement::VecString(result))
-                    },
+                    }
                 }
-            },
-            None => None
+            }
+            None => None,
         }
     }
 }
-
 
 #[cfg(test)]
 #[path = "./definition_arguments_test.rs"]

--- a/src/task_definition/definition_arguments.rs
+++ b/src/task_definition/definition_arguments.rs
@@ -60,13 +60,13 @@ fn string_to_vec_of_string(mut s: String) -> Vec<String> {
 }
 
 impl DefinitionArguments {
-    fn new() -> Self {
+    pub fn new() -> Self {
         DefinitionArguments {
             map: HashMap::new()
         }
     }
 
-    fn set(&mut self, key: &String, value: String, da_type: DefinitionArgumentType) {
+    pub fn set(&mut self, key: &String, value: String, da_type: DefinitionArgumentType) {
         self.map.insert(key.to_string(), (value, da_type));
     }
 

--- a/src/task_definition/definition_arguments.rs
+++ b/src/task_definition/definition_arguments.rs
@@ -30,7 +30,7 @@ pub struct DefinitionArguments {
 }
 
 // todo: temporary, use a library or something more efficient and fail-proff
-/// Convert a string containing a JSON array to a Vec of string 
+/// Convert a string containing a JSON array to a Vec of string
 fn string_to_vec_of_string(mut s: String) -> Vec<String> {
     let mut res = Vec::new();
     s.remove(0);

--- a/src/task_definition/definition_arguments.rs
+++ b/src/task_definition/definition_arguments.rs
@@ -1,0 +1,108 @@
+use crate::type_definition::FilePath;
+use std::collections::HashMap;
+
+
+// todo: move to new module
+// todo: review visibility
+#[derive(Debug, Clone, Copy)]
+pub enum DefinitionArgumentType {
+    AString,  // A-string to differentiate from type
+    Filepath,
+    Integer,
+    Float,
+    VecString
+}
+
+pub enum DefinitionArgumentElement {
+    AString(String),
+    Filepath(FilePath),
+    Integer(i64),
+    Float(f64),
+    /// Vec of string as JSON array
+    VecString(Vec<String>)
+}
+
+pub struct DefinitionArguments {
+    map: HashMap<String, (String, DefinitionArgumentType)>
+}
+
+// todo: temporary, use a library or something more efficient and fail-proff
+fn string_to_vec_of_string(mut s: String) -> Vec<String> {
+    let mut res = Vec::new();
+    s.remove(0);
+    s.remove(s.len() - 1);
+    if s.is_empty() {
+        return res
+    }
+    // basic iterative algo
+    let mut opened_quotes = false;
+    let mut buffer = String::new();
+    for c in s.chars() {
+        if c == '\"' {
+            if opened_quotes {
+                // closing expression
+                res.push(buffer);
+                opened_quotes = false;
+                buffer = String::new();
+            } else {
+                // opening expression
+                opened_quotes = true;
+            }
+        } else {
+            if opened_quotes {
+                // add to current
+                buffer.push(c);
+            }
+        }
+    }
+    res
+}
+
+impl DefinitionArguments {
+    fn new() -> Self {
+        DefinitionArguments {
+            map: HashMap::new()
+        }
+    }
+
+    fn set(&mut self, key: String, value: String, da_type: DefinitionArgumentType) {
+        self.map.insert(key, (value, da_type));
+    }
+
+    pub fn get(&self, key: &String) -> Option<DefinitionArgumentElement> {
+        match self.map.get(key) {
+            Some((v, t)) => {
+                let value = v.to_string();
+                match t {
+                    DefinitionArgumentType::AString => {
+                        Some(DefinitionArgumentElement::AString(value))
+                    },
+                    DefinitionArgumentType::Filepath => {
+                        let fp = FilePath::from(value);
+                        Some(DefinitionArgumentElement::Filepath(fp))
+                    },
+                    DefinitionArgumentType::Integer => {
+                        let as_int = value.parse::<i64>().unwrap();
+                        Some(DefinitionArgumentElement::Integer(as_int))
+                    },
+                    DefinitionArgumentType::Float => {
+                        let as_float = value.parse::<f64>().unwrap();
+                        Some(DefinitionArgumentElement::Float(as_float))
+                    },
+                    DefinitionArgumentType::VecString => {
+                        // from JSON format
+                        // todo: use a library (serde?)
+                        let result = string_to_vec_of_string(value);               
+                        Some(DefinitionArgumentElement::VecString(result))
+                    },
+                }
+            },
+            None => None
+        }
+    }
+}
+
+
+#[cfg(test)]
+#[path = "./definition_arguments_test.rs"]
+mod definition_arguments_test;

--- a/src/task_definition/definition_arguments.rs
+++ b/src/task_definition/definition_arguments.rs
@@ -1,8 +1,9 @@
 use crate::type_definition::FilePath;
 use std::collections::HashMap;
 
-// todo: move to new module
 // todo: review visibility
+/// Identify what type of argument we're saving.
+/// Allow to parse back a string saved
 #[derive(Debug, Clone, Copy)]
 pub enum DefinitionArgumentType {
     AString, // A-string to differentiate from type
@@ -12,6 +13,7 @@ pub enum DefinitionArgumentType {
     VecString,
 }
 
+/// One stored argument to create a new definition
 #[derive(Debug, PartialEq)]
 pub enum DefinitionArgumentElement {
     AString(String),
@@ -22,11 +24,13 @@ pub enum DefinitionArgumentElement {
     VecString(Vec<String>),
 }
 
+/// Save the arguments to pass to a definition
 pub struct DefinitionArguments {
     map: HashMap<String, (String, DefinitionArgumentType)>,
 }
 
 // todo: temporary, use a library or something more efficient and fail-proff
+/// Convert a string containing a JSON array to a Vec of string 
 fn string_to_vec_of_string(mut s: String) -> Vec<String> {
     let mut res = Vec::new();
     s.remove(0);
@@ -58,6 +62,7 @@ fn string_to_vec_of_string(mut s: String) -> Vec<String> {
     res
 }
 
+/// Grouped arguments to create a new definition
 impl DefinitionArguments {
     pub fn new() -> Self {
         DefinitionArguments {

--- a/src/task_definition/definition_arguments.rs
+++ b/src/task_definition/definition_arguments.rs
@@ -13,6 +13,7 @@ pub enum DefinitionArgumentType {
     VecString
 }
 
+#[derive(Debug, PartialEq)]
 pub enum DefinitionArgumentElement {
     AString(String),
     Filepath(FilePath),
@@ -65,8 +66,8 @@ impl DefinitionArguments {
         }
     }
 
-    fn set(&mut self, key: String, value: String, da_type: DefinitionArgumentType) {
-        self.map.insert(key, (value, da_type));
+    fn set(&mut self, key: &String, value: String, da_type: DefinitionArgumentType) {
+        self.map.insert(key.to_string(), (value, da_type));
     }
 
     pub fn get(&self, key: &String) -> Option<DefinitionArgumentElement> {

--- a/src/task_definition/definition_arguments_test.rs
+++ b/src/task_definition/definition_arguments_test.rs
@@ -1,0 +1,4 @@
+#[test]
+fn test_() {
+    assert_eq!(1, 2);
+}

--- a/src/task_definition/definition_arguments_test.rs
+++ b/src/task_definition/definition_arguments_test.rs
@@ -1,7 +1,5 @@
 use crate::task_definition::{
-    DefinitionArguments, 
-    DefinitionArgumentType,
-    DefinitionArgumentElement
+    DefinitionArgumentElement, DefinitionArgumentType, DefinitionArguments,
 };
 
 #[test]
@@ -33,7 +31,7 @@ fn test_getting_converts_to_type() {
     let expected = vec![
         String::from("one"),
         String::from("two"),
-        String::from("three")
+        String::from("three"),
     ];
     let da_type = DefinitionArgumentType::VecString;
 

--- a/src/task_definition/definition_arguments_test.rs
+++ b/src/task_definition/definition_arguments_test.rs
@@ -1,4 +1,14 @@
 #[test]
-fn test_() {
+fn test_setting_value() {
+    assert_eq!(1, 2);
+}
+
+#[test]
+fn test_getting_unknown_key_is_none() {
+    assert_eq!(1, 2);
+}
+
+#[test]
+fn test_getting_converts_to_type() {
     assert_eq!(1, 2);
 }

--- a/src/task_definition/definition_arguments_test.rs
+++ b/src/task_definition/definition_arguments_test.rs
@@ -1,14 +1,45 @@
+use crate::task_definition::{
+    DefinitionArguments, 
+    DefinitionArgumentType,
+    DefinitionArgumentElement
+};
+
 #[test]
 fn test_setting_value() {
-    assert_eq!(1, 2);
+    let mut da = DefinitionArguments::new();
+    let key = String::from("my-key");
+    let value = String::from("my-value");
+    let da_type = DefinitionArgumentType::AString;
+
+    da.set(&key, value.clone(), da_type);
+    assert!(da.map.get(&key).is_some());
+    let returned_value = da.get(&key).unwrap();
+    assert_eq!(returned_value, (DefinitionArgumentElement::AString(value)));
 }
 
 #[test]
 fn test_getting_unknown_key_is_none() {
-    assert_eq!(1, 2);
+    let da = DefinitionArguments::new();
+    let key = String::from("my-key");
+    let res = da.get(&key);
+    assert!(res.is_none());
 }
 
 #[test]
 fn test_getting_converts_to_type() {
-    assert_eq!(1, 2);
+    let mut da = DefinitionArguments::new();
+    let key = String::from("my-key");
+    let value = String::from("[\"one\", \"two\", \"three\"]");
+    let expected = vec![
+        String::from("one"),
+        String::from("two"),
+        String::from("three")
+    ];
+    let da_type = DefinitionArgumentType::VecString;
+
+    da.set(&key, value.clone(), da_type);
+    let res = da.get(&key);
+    assert!(res.is_some());
+    let res_value = res.unwrap();
+    assert_eq!(res_value, DefinitionArgumentElement::VecString(expected));
 }

--- a/src/task_definition/definition_factory.rs
+++ b/src/task_definition/definition_factory.rs
@@ -11,7 +11,7 @@ use crate::task_definition::DefinitionArguments;
 pub enum TaskDefinitionType {
     Bash,
     Python,
-    Dummy,
+    Dummy
 }
 
 /// Given a string, return an enum that link to a definition variant
@@ -24,28 +24,23 @@ pub fn string_to_definition_type(def_name: String) -> Option<TaskDefinitionType>
     }
 }
 
-/// Factory to create new TaskDefinition
-struct DefinitionFactory;
-
-impl DefinitionFactory {
-    /// Given a type of task and the arguments to pass it, create a new instance
-    fn new_definition(tdt: &TaskDefinitionType, arguments: DefinitionArguments) -> Box<dyn TaskDefinition> {
-        match tdt {
-            TaskDefinitionType::Bash => {
-                let b_def = BashTaskDefinition::from(arguments);
-                Box::new(b_def)
-            },
-            TaskDefinitionType::Python => {
-                let p_def = PythonTaskDefinition::from(arguments);
-                Box::new(p_def)
-            },
-            TaskDefinitionType::Dummy => {
-                let d_def = DummyTaskDefinition::from(arguments);
-                Box::new(d_def)
-            },
-            _ => {
-                panic!("Definition type not linked to TaskDefinition: {:?}", tdt);
-            }
+/// Given a type of task and the arguments to pass it, create a new instance
+pub fn create_new_definition(tdt: &TaskDefinitionType, arguments: DefinitionArguments) -> Box<dyn TaskDefinition> {
+    match tdt {
+        TaskDefinitionType::Bash => {
+            let b_def = BashTaskDefinition::from(arguments);
+            Box::new(b_def)
+        },
+        TaskDefinitionType::Python => {
+            let p_def = PythonTaskDefinition::from(arguments);
+            Box::new(p_def)
+        },
+        TaskDefinitionType::Dummy => {
+            let d_def = DummyTaskDefinition::from(arguments);
+            Box::new(d_def)
+        },
+        _ => {
+            panic!("Definition type not linked to TaskDefinition: {:?}", tdt);
         }
     }
 }

--- a/src/task_definition/definition_factory.rs
+++ b/src/task_definition/definition_factory.rs
@@ -1,11 +1,11 @@
-use crate::type_definition::FilePath;
 use crate::task_definition::{
     DummyTaskDefinition, 
     BashTaskDefinition, 
     PythonTaskDefinition, 
     TaskDefinition
 };
-use std::collections::HashMap;
+use crate::type_definition::FilePath;
+use crate::task_definition::DefinitionArguments;
 
 /// Enum identifying the variant of Definition
 #[derive(Debug, PartialEq)]
@@ -22,106 +22,6 @@ pub fn string_to_definition_type(def_name: String) -> Option<TaskDefinitionType>
         "bash_task_definition" => Some(TaskDefinitionType::Bash),
         "dummy_task_definition" => Some(TaskDefinitionType::Dummy),
         _ => None,
-    }
-}
-
-// todo: move to new module
-// todo: review visibility
-#[derive(Debug, Clone, Copy)]
-pub enum DefinitionArgumentType {
-    AString,  // A-string to differentiate from type
-    Filepath,
-    Integer,
-    Float,
-    VecString
-}
-
-pub enum DefinitionArgumentElement {
-    AString(String),
-    Filepath(FilePath),
-    Integer(i64),
-    Float(f64),
-    /// Vec of string as JSON array
-    VecString(Vec<String>)
-}
-
-pub struct DefinitionArguments {
-    map: HashMap<String, (String, DefinitionArgumentType)>
-}
-
-// todo: temporary, use a library or something more efficient and fail-proff
-fn string_to_vec_of_string(mut s: String) -> Vec<String> {
-    let mut res = Vec::new();
-    s.remove(0);
-    s.remove(s.len() - 1);
-    if s.is_empty() {
-        return res
-    }
-    // basic iterative algo
-    let mut opened_quotes = false;
-    let mut buffer = String::new();
-    for c in s.chars() {
-        if c == '\"' {
-            if opened_quotes {
-                // closing expression
-                res.push(buffer);
-                opened_quotes = false;
-                buffer = String::new();
-            } else {
-                // opening expression
-                opened_quotes = true;
-            }
-        } else {
-            if opened_quotes {
-                // add to current
-                buffer.push(c);
-            }
-        }
-    }
-    res
-}
-
-impl DefinitionArguments {
-    fn new() -> Self {
-        DefinitionArguments {
-            map: HashMap::new()
-        }
-    }
-
-    fn set(&mut self, key: String, value: String, da_type: DefinitionArgumentType) {
-        self.map.insert(key, (value, da_type));
-    }
-
-    pub fn get(&self, key: &String) -> Option<DefinitionArgumentElement> {
-        match self.map.get(key) {
-            Some((v, t)) => {
-                let value = v.to_string();
-                match t {
-                    DefinitionArgumentType::AString => {
-                        Some(DefinitionArgumentElement::AString(value))
-                    },
-                    DefinitionArgumentType::Filepath => {
-                        let fp = FilePath::from(value);
-                        Some(DefinitionArgumentElement::Filepath(fp))
-                    },
-                    DefinitionArgumentType::Integer => {
-                        let as_int = value.parse::<i64>().unwrap();
-                        Some(DefinitionArgumentElement::Integer(as_int))
-                    },
-                    DefinitionArgumentType::Float => {
-                        let as_float = value.parse::<f64>().unwrap();
-                        Some(DefinitionArgumentElement::Float(as_float))
-                    },
-                    DefinitionArgumentType::VecString => {
-                        // from JSON format
-                        // todo: use a library (serde?)
-                        let result = string_to_vec_of_string(value);               
-                        Some(DefinitionArgumentElement::VecString(result))
-                    },
-                }
-            },
-            None => None
-        }
     }
 }
 

--- a/src/task_definition/definition_factory.rs
+++ b/src/task_definition/definition_factory.rs
@@ -24,7 +24,13 @@ pub fn string_to_definition_type(def_name: String) -> Option<TaskDefinitionType>
     }
 }
 
-struct DefinitionArguments;
+pub struct DefinitionArguments;
+
+impl DefinitionArguments {
+    fn get(key: str) -> String {
+        String::from("to impl")
+    }
+}
 
 struct DefinitionFactory;
 

--- a/src/task_definition/definition_factory.rs
+++ b/src/task_definition/definition_factory.rs
@@ -1,0 +1,23 @@
+
+/// Enum identifying the variant of Definition
+#[derive(Debug, PartialEq)]
+pub enum TaskDefinitionType {
+    Bash,
+    Python,
+    Dummy,
+}
+
+/// Given a string, return an enum that link to a definition variant
+pub fn string_to_definition_type(def_name: String) -> Option<TaskDefinitionType> {
+    match def_name.as_str() {
+        "python_task_definition" => Some(TaskDefinitionType::Python),
+        "bash_task_definition" => Some(TaskDefinitionType::Bash),
+        "dummy_task_definition" => Some(TaskDefinitionType::Dummy),
+        _ => None,
+    }
+}
+
+
+#[cfg(test)]
+#[path = "./definition_factory_test.rs"]
+mod definition_factory_test;

--- a/src/task_definition/definition_factory.rs
+++ b/src/task_definition/definition_factory.rs
@@ -1,17 +1,14 @@
-use crate::task_definition::{
-    DummyTaskDefinition, 
-    BashTaskDefinition, 
-    PythonTaskDefinition, 
-    TaskDefinition
-};
 use crate::task_definition::DefinitionArguments;
+use crate::task_definition::{
+    BashTaskDefinition, DummyTaskDefinition, PythonTaskDefinition, TaskDefinition,
+};
 
 /// Enum identifying the variant of Definition
 #[derive(Debug, PartialEq)]
 pub enum TaskDefinitionType {
     Bash,
     Python,
-    Dummy
+    Dummy,
 }
 
 /// Given a string, return an enum that link to a definition variant
@@ -25,20 +22,23 @@ pub fn string_to_definition_type(def_name: String) -> Option<TaskDefinitionType>
 }
 
 /// Given a type of task and the arguments to pass it, create a new instance
-pub fn create_new_definition(tdt: &TaskDefinitionType, arguments: DefinitionArguments) -> Box<dyn TaskDefinition> {
+pub fn create_new_definition(
+    tdt: &TaskDefinitionType,
+    arguments: DefinitionArguments,
+) -> Box<dyn TaskDefinition> {
     match tdt {
         TaskDefinitionType::Bash => {
             let b_def = BashTaskDefinition::from(arguments);
             Box::new(b_def)
-        },
+        }
         TaskDefinitionType::Python => {
             let p_def = PythonTaskDefinition::from(arguments);
             Box::new(p_def)
-        },
+        }
         TaskDefinitionType::Dummy => {
             let d_def = DummyTaskDefinition::from(arguments);
             Box::new(d_def)
-        },
+        }
         _ => {
             panic!("Definition type not linked to TaskDefinition: {:?}", tdt);
         }

--- a/src/task_definition/definition_factory.rs
+++ b/src/task_definition/definition_factory.rs
@@ -5,6 +5,7 @@ use crate::task_definition::{
     PythonTaskDefinition, 
     TaskDefinition
 };
+use std::collections::HashMap;
 
 /// Enum identifying the variant of Definition
 #[derive(Debug, PartialEq)]
@@ -24,17 +25,111 @@ pub fn string_to_definition_type(def_name: String) -> Option<TaskDefinitionType>
     }
 }
 
-pub struct DefinitionArguments;
+// todo: move to new module
+// todo: review visibility
+#[derive(Debug, Clone, Copy)]
+pub enum DefinitionArgumentType {
+    AString,  // A-string to differentiate from type
+    Filepath,
+    Integer,
+    Float,
+    VecString
+}
+
+pub enum DefinitionArgumentElement {
+    AString(String),
+    Filepath(FilePath),
+    Integer(i64),
+    Float(f64),
+    /// Vec of string as JSON array
+    VecString(Vec<String>)
+}
+
+pub struct DefinitionArguments {
+    map: HashMap<String, (String, DefinitionArgumentType)>
+}
+
+// todo: temporary, use a library or something more efficient and fail-proff
+fn string_to_vec_of_string(mut s: String) -> Vec<String> {
+    let mut res = Vec::new();
+    s.remove(0);
+    s.remove(s.len() - 1);
+    if s.is_empty() {
+        return res
+    }
+    // basic iterative algo
+    let mut opened_quotes = false;
+    let mut buffer = String::new();
+    for c in s.chars() {
+        if c == '\"' {
+            if opened_quotes {
+                // closing expression
+                res.push(buffer);
+                opened_quotes = false;
+                buffer = String::new();
+            } else {
+                // opening expression
+                opened_quotes = true;
+            }
+        } else {
+            if opened_quotes {
+                // add to current
+                buffer.push(c);
+            }
+        }
+    }
+    res
+}
 
 impl DefinitionArguments {
-    fn get(key: str) -> String {
-        String::from("to impl")
+    fn new() -> Self {
+        DefinitionArguments {
+            map: HashMap::new()
+        }
+    }
+
+    fn set(&mut self, key: String, value: String, da_type: DefinitionArgumentType) {
+        self.map.insert(key, (value, da_type));
+    }
+
+    pub fn get(&self, key: &String) -> Option<DefinitionArgumentElement> {
+        match self.map.get(key) {
+            Some((v, t)) => {
+                let value = v.to_string();
+                match t {
+                    DefinitionArgumentType::AString => {
+                        Some(DefinitionArgumentElement::AString(value))
+                    },
+                    DefinitionArgumentType::Filepath => {
+                        let fp = FilePath::from(value);
+                        Some(DefinitionArgumentElement::Filepath(fp))
+                    },
+                    DefinitionArgumentType::Integer => {
+                        let as_int = value.parse::<i64>().unwrap();
+                        Some(DefinitionArgumentElement::Integer(as_int))
+                    },
+                    DefinitionArgumentType::Float => {
+                        let as_float = value.parse::<f64>().unwrap();
+                        Some(DefinitionArgumentElement::Float(as_float))
+                    },
+                    DefinitionArgumentType::VecString => {
+                        // from JSON format
+                        // todo: use a library (serde?)
+                        let result = string_to_vec_of_string(value);               
+                        Some(DefinitionArgumentElement::VecString(result))
+                    },
+                }
+            },
+            None => None
+        }
     }
 }
 
+/// Factory to create new TaskDefinition
 struct DefinitionFactory;
 
 impl DefinitionFactory {
+    /// Given a type of task and the arguments to pass it, create a new instance
     fn new_definition(tdt: &TaskDefinitionType, arguments: &DefinitionArguments) -> Box<dyn TaskDefinition> {
         match tdt {
             TaskDefinitionType::Bash => {

--- a/src/task_definition/definition_factory.rs
+++ b/src/task_definition/definition_factory.rs
@@ -1,3 +1,10 @@
+use crate::type_definition::FilePath;
+use crate::task_definition::{
+    DummyTaskDefinition, 
+    BashTaskDefinition, 
+    PythonTaskDefinition, 
+    TaskDefinition
+};
 
 /// Enum identifying the variant of Definition
 #[derive(Debug, PartialEq)]
@@ -17,6 +24,32 @@ pub fn string_to_definition_type(def_name: String) -> Option<TaskDefinitionType>
     }
 }
 
+struct DefinitionArguments;
+
+struct DefinitionFactory;
+
+impl DefinitionFactory {
+    fn new_definition(tdt: &TaskDefinitionType, arguments: &DefinitionArguments) -> Box<dyn TaskDefinition> {
+        match tdt {
+            TaskDefinitionType::Bash => {
+                let b_def = BashTaskDefinition::new(vec!["echo 'Hello'".to_string()]);
+                Box::new(b_def)
+            },
+            TaskDefinitionType::Python => {
+                let script_path = FilePath::from("script.py");
+                let p_def = PythonTaskDefinition::new(script_path, vec![]);
+                Box::new(p_def)
+            },
+            TaskDefinitionType::Dummy => {
+                let d_def = DummyTaskDefinition::new();
+                Box::new(d_def)
+            },
+            _ => {
+                panic!("Definition type not linked to TaskDefinition: {:?}", tdt);
+            }
+        }
+    }
+}
 
 #[cfg(test)]
 #[path = "./definition_factory_test.rs"]

--- a/src/task_definition/definition_factory.rs
+++ b/src/task_definition/definition_factory.rs
@@ -4,7 +4,6 @@ use crate::task_definition::{
     PythonTaskDefinition, 
     TaskDefinition
 };
-use crate::type_definition::FilePath;
 use crate::task_definition::DefinitionArguments;
 
 /// Enum identifying the variant of Definition
@@ -30,19 +29,18 @@ struct DefinitionFactory;
 
 impl DefinitionFactory {
     /// Given a type of task and the arguments to pass it, create a new instance
-    fn new_definition(tdt: &TaskDefinitionType, arguments: &DefinitionArguments) -> Box<dyn TaskDefinition> {
+    fn new_definition(tdt: &TaskDefinitionType, arguments: DefinitionArguments) -> Box<dyn TaskDefinition> {
         match tdt {
             TaskDefinitionType::Bash => {
-                let b_def = BashTaskDefinition::new(vec!["echo 'Hello'".to_string()]);
+                let b_def = BashTaskDefinition::from(arguments);
                 Box::new(b_def)
             },
             TaskDefinitionType::Python => {
-                let script_path = FilePath::from("script.py");
-                let p_def = PythonTaskDefinition::new(script_path, vec![]);
+                let p_def = PythonTaskDefinition::from(arguments);
                 Box::new(p_def)
             },
             TaskDefinitionType::Dummy => {
-                let d_def = DummyTaskDefinition::new();
+                let d_def = DummyTaskDefinition::from(arguments);
                 Box::new(d_def)
             },
             _ => {

--- a/src/task_definition/definition_factory_test.rs
+++ b/src/task_definition/definition_factory_test.rs
@@ -1,0 +1,4 @@
+#[test]
+fn test() {
+    assert_eq!(1, 2);
+}

--- a/src/task_definition/definition_factory_test.rs
+++ b/src/task_definition/definition_factory_test.rs
@@ -2,3 +2,18 @@
 fn test() {
     assert_eq!(1, 2);
 }
+
+#[test]
+fn it_can_create_bash_def() {
+    assert_eq!(1, 2);
+}
+
+#[test]
+fn it_can_create_python_def() {
+    assert_eq!(1, 2);
+}
+
+#[test]
+fn it_can_create_dummy_def() {
+    assert_eq!(1, 2);
+}

--- a/src/task_definition/definition_factory_test.rs
+++ b/src/task_definition/definition_factory_test.rs
@@ -1,8 +1,5 @@
 use crate::task_definition::{
-    TaskDefinitionType,
-    DefinitionArguments,
-    DefinitionArgumentType,
-    create_new_definition
+    create_new_definition, DefinitionArgumentType, DefinitionArguments, TaskDefinitionType,
 };
 use std::collections::HashMap;
 
@@ -11,14 +8,14 @@ fn it_can_create_bash_def() {
     let mut da = DefinitionArguments::new();
     let command = "[\"echo\", \"'1'\"]".to_string();
     da.set(
-        &"command".to_string(), 
-        command.clone(), 
-        DefinitionArgumentType::VecString
+        &"command".to_string(),
+        command.clone(),
+        DefinitionArgumentType::VecString,
     );
-    
+
     let b_def = create_new_definition(&TaskDefinitionType::Bash, da);
     assert_eq!(b_def.task_type(), TaskDefinitionType::Bash);
-    
+
     let mut expected_params = HashMap::new();
     // in BashTaskDefinition.get_params, we concatenate in one
     expected_params.insert("command".to_string(), "echo \'1\'".to_string());
@@ -31,19 +28,19 @@ fn it_can_create_python_def() {
     let script_path = String::from("/tmp/script.py");
     let args = String::from("[\"one\"]");
     da.set(
-        &"script_path".to_string(), 
-        script_path.clone(), 
-        DefinitionArgumentType::Filepath
+        &"script_path".to_string(),
+        script_path.clone(),
+        DefinitionArgumentType::Filepath,
     );
     da.set(
         &"args".to_string(),
-        args.clone(), 
-        DefinitionArgumentType::VecString
+        args.clone(),
+        DefinitionArgumentType::VecString,
     );
-    
+
     let p_def = create_new_definition(&TaskDefinitionType::Python, da);
     assert_eq!(p_def.task_type(), TaskDefinitionType::Python);
-    
+
     let mut expected_params = HashMap::new();
     expected_params.insert("script_path".to_string(), script_path.to_string());
     // in get_params, we remove the doublequotes

--- a/src/task_definition/definition_factory_test.rs
+++ b/src/task_definition/definition_factory_test.rs
@@ -1,19 +1,59 @@
-#[test]
-fn test_unknown_type() {
-    assert_eq!(1, 2);
-}
+use crate::task_definition::{
+    TaskDefinitionType,
+    DefinitionArguments,
+    DefinitionArgumentType,
+    create_new_definition
+};
+use std::collections::HashMap;
 
 #[test]
 fn it_can_create_bash_def() {
-    assert_eq!(1, 2);
+    let mut da = DefinitionArguments::new();
+    let command = "[\"echo\", \"'1'\"]".to_string();
+    da.set(
+        &"command".to_string(), 
+        command.clone(), 
+        DefinitionArgumentType::VecString
+    );
+    
+    let b_def = create_new_definition(&TaskDefinitionType::Bash, da);
+    assert_eq!(b_def.task_type(), TaskDefinitionType::Bash);
+    
+    let mut expected_params = HashMap::new();
+    // in BashTaskDefinition.get_params, we concatenate in one
+    expected_params.insert("command".to_string(), "echo \'1\'".to_string());
+    assert_eq!(b_def.get_params(), expected_params);
 }
 
 #[test]
 fn it_can_create_python_def() {
-    assert_eq!(1, 2);
+    let mut da = DefinitionArguments::new();
+    let script_path = String::from("/tmp/script.py");
+    let args = String::from("[\"one\"]");
+    da.set(
+        &"script_path".to_string(), 
+        script_path.clone(), 
+        DefinitionArgumentType::Filepath
+    );
+    da.set(
+        &"args".to_string(),
+        args.clone(), 
+        DefinitionArgumentType::VecString
+    );
+    
+    let p_def = create_new_definition(&TaskDefinitionType::Python, da);
+    assert_eq!(p_def.task_type(), TaskDefinitionType::Python);
+    
+    let mut expected_params = HashMap::new();
+    expected_params.insert("script_path".to_string(), script_path.to_string());
+    // in get_params, we remove the doublequotes
+    expected_params.insert("args".to_string(), "[one]".to_string());
+    assert_eq!(p_def.get_params(), expected_params);
 }
 
 #[test]
 fn it_can_create_dummy_def() {
-    assert_eq!(1, 2);
+    let da = DefinitionArguments::new();
+    let d_def = create_new_definition(&TaskDefinitionType::Dummy, da);
+    assert_eq!(d_def.task_type(), TaskDefinitionType::Dummy);
 }

--- a/src/task_definition/definition_factory_test.rs
+++ b/src/task_definition/definition_factory_test.rs
@@ -1,5 +1,5 @@
 #[test]
-fn test() {
+fn test_unknown_type() {
     assert_eq!(1, 2);
 }
 

--- a/src/task_definition/dummy_task.rs
+++ b/src/task_definition/dummy_task.rs
@@ -26,3 +26,9 @@ impl TaskDefinition for DummyTaskDefinition {
         HashMap::new()
     }
 }
+
+impl DummyTaskDefinition {
+    pub fn new() -> Self {
+        DummyTaskDefinition {}
+    }
+}

--- a/src/task_definition/dummy_task.rs
+++ b/src/task_definition/dummy_task.rs
@@ -1,5 +1,5 @@
 use crate::errors::YoshiError;
-use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType};
+use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType, DefinitionArguments};
 use crate::task_output::TaskOutput;
 use crate::type_definition::TaskId;
 use std::collections::HashMap;
@@ -8,6 +8,12 @@ use std::collections::HashMap;
 /// use to sync
 #[derive(Clone, Debug)]
 pub struct DummyTaskDefinition {}
+
+impl From<DefinitionArguments> for DummyTaskDefinition {
+    fn from(da: DefinitionArguments) -> Self {
+        DummyTaskDefinition::new()
+    }
+}
 
 impl TaskDefinition for DummyTaskDefinition {
     fn task_definition_id(&self) -> TaskId {

--- a/src/task_definition/dummy_task.rs
+++ b/src/task_definition/dummy_task.rs
@@ -1,5 +1,7 @@
 use crate::errors::YoshiError;
-use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType, DefinitionArguments};
+use crate::task_definition::{
+    generate_task_definition_id, DefinitionArguments, TaskDefinition, TaskDefinitionType,
+};
 use crate::task_output::TaskOutput;
 use crate::type_definition::TaskId;
 use std::collections::HashMap;

--- a/src/task_definition/mod.rs
+++ b/src/task_definition/mod.rs
@@ -15,5 +15,5 @@ pub use definition_arguments::{
     DefinitionArguments, DefinitionArgumentType, DefinitionArgumentElement
 };
 pub use definition_factory::{
-    string_to_definition_type, TaskDefinitionType
+    create_new_definition, string_to_definition_type, TaskDefinitionType
 };

--- a/src/task_definition/mod.rs
+++ b/src/task_definition/mod.rs
@@ -3,6 +3,7 @@ mod dummy_task;
 mod python_task;
 mod task_def;
 mod definition_factory;
+mod definition_arguments;
 
 pub use bash_task::BashTaskDefinition;
 pub use dummy_task::DummyTaskDefinition;
@@ -10,6 +11,9 @@ pub use python_task::PythonTaskDefinition;
 pub use task_def::{
     generate_task_definition_id, TaskDefinition
 };
+pub use definition_arguments::{
+    DefinitionArguments, DefinitionArgumentType, DefinitionArgumentElement
+};
 pub use definition_factory::{
-    string_to_definition_type, TaskDefinitionType, DefinitionArguments, DefinitionArgumentType, DefinitionArgumentElement
+    string_to_definition_type, TaskDefinitionType
 };

--- a/src/task_definition/mod.rs
+++ b/src/task_definition/mod.rs
@@ -2,10 +2,14 @@ mod bash_task;
 mod dummy_task;
 mod python_task;
 mod task_def;
+mod definition_factory;
 
 pub use bash_task::BashTaskDefinition;
 pub use dummy_task::DummyTaskDefinition;
 pub use python_task::PythonTaskDefinition;
 pub use task_def::{
-    generate_task_definition_id, string_to_definition_type, TaskDefinition, TaskDefinitionType,
+    generate_task_definition_id, TaskDefinition
+};
+pub use definition_factory::{
+    string_to_definition_type, TaskDefinitionType
 };

--- a/src/task_definition/mod.rs
+++ b/src/task_definition/mod.rs
@@ -1,19 +1,17 @@
 mod bash_task;
+mod definition_arguments;
+mod definition_factory;
 mod dummy_task;
 mod python_task;
 mod task_def;
-mod definition_factory;
-mod definition_arguments;
 
 pub use bash_task::BashTaskDefinition;
-pub use dummy_task::DummyTaskDefinition;
-pub use python_task::PythonTaskDefinition;
-pub use task_def::{
-    generate_task_definition_id, TaskDefinition
-};
 pub use definition_arguments::{
-    DefinitionArguments, DefinitionArgumentType, DefinitionArgumentElement
+    DefinitionArgumentElement, DefinitionArgumentType, DefinitionArguments,
 };
 pub use definition_factory::{
-    create_new_definition, string_to_definition_type, TaskDefinitionType
+    create_new_definition, string_to_definition_type, TaskDefinitionType,
 };
+pub use dummy_task::DummyTaskDefinition;
+pub use python_task::PythonTaskDefinition;
+pub use task_def::{generate_task_definition_id, TaskDefinition};

--- a/src/task_definition/mod.rs
+++ b/src/task_definition/mod.rs
@@ -11,5 +11,5 @@ pub use task_def::{
     generate_task_definition_id, TaskDefinition
 };
 pub use definition_factory::{
-    string_to_definition_type, TaskDefinitionType
+    string_to_definition_type, TaskDefinitionType, DefinitionArguments
 };

--- a/src/task_definition/mod.rs
+++ b/src/task_definition/mod.rs
@@ -11,5 +11,5 @@ pub use task_def::{
     generate_task_definition_id, TaskDefinition
 };
 pub use definition_factory::{
-    string_to_definition_type, TaskDefinitionType, DefinitionArguments
+    string_to_definition_type, TaskDefinitionType, DefinitionArguments, DefinitionArgumentType, DefinitionArgumentElement
 };

--- a/src/task_definition/python_task.rs
+++ b/src/task_definition/python_task.rs
@@ -1,5 +1,8 @@
 use crate::errors::YoshiError;
-use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType, DefinitionArguments, DefinitionArgumentElement};
+use crate::task_definition::{
+    generate_task_definition_id, DefinitionArgumentElement, DefinitionArguments, TaskDefinition,
+    TaskDefinitionType,
+};
 use crate::task_output::TaskOutput;
 use crate::type_definition::{FilePath, TaskId};
 use log::{debug, error, info};
@@ -24,9 +27,9 @@ impl From<DefinitionArguments> for PythonTaskDefinition {
             match e {
                 DefinitionArgumentElement::Filepath(fp) => {
                     script_path = fp;
-                },
+                }
                 _ => {
-                    panic!("'script_path' for PythonTask must be a Filepath");    
+                    panic!("'script_path' for PythonTask must be a Filepath");
                 }
             }
         }
@@ -34,7 +37,7 @@ impl From<DefinitionArguments> for PythonTaskDefinition {
             match e {
                 DefinitionArgumentElement::VecString(vs) => {
                     args = vs;
-                },
+                }
                 _ => {
                     panic!("'args' for PythonTask must be a VecString");
                 }

--- a/src/task_definition/python_task.rs
+++ b/src/task_definition/python_task.rs
@@ -99,11 +99,13 @@ impl TaskDefinition for PythonTaskDefinition {
         let script_path_string = script_path_copy.into_string().unwrap();
         params.insert("script_path".to_string(), script_path_string);
 
-        let mut arg_string = "".to_string();
+        let mut arg_string = "[".to_string();
         for arg in self.args.iter() {
             arg_string.push_str(&arg);
             arg_string.push_str(" ");
         }
+        arg_string.pop();
+        arg_string.push_str("]");
         params.insert("args".to_string(), arg_string);
         params
     }

--- a/src/task_definition/python_task.rs
+++ b/src/task_definition/python_task.rs
@@ -32,6 +32,8 @@ impl From<DefinitionArguments> for PythonTaskDefinition {
                     panic!("'script_path' for PythonTask must be a Filepath");
                 }
             }
+        } else {
+            panic!("Not found mandatory argument 'script_path' for PythonTask");
         }
         if let Some(e) = da.get(&"args".to_string()) {
             match e {
@@ -42,6 +44,8 @@ impl From<DefinitionArguments> for PythonTaskDefinition {
                     panic!("'args' for PythonTask must be a VecString");
                 }
             }
+        } else {
+            panic!("Not found mandatory argument 'args' for PythonTask");
         }
         PythonTaskDefinition::new(script_path, args)
     }

--- a/src/task_definition/python_task.rs
+++ b/src/task_definition/python_task.rs
@@ -1,5 +1,5 @@
 use crate::errors::YoshiError;
-use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType};
+use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType, DefinitionArguments};
 use crate::task_output::TaskOutput;
 use crate::type_definition::{FilePath, TaskId};
 use log::{debug, error, info};
@@ -14,6 +14,20 @@ pub struct PythonTaskDefinition {
     task_def_id: TaskId,
     script_path: Box<FilePath>,
     args: Vec<String>,
+}
+
+impl From<DefinitionArguments> for PythonTaskDefinition {
+    fn from(da: DefinitionArguments) -> Self {
+        let script_path = da.params.get("script_path").unwrap();
+        let args_string = da.params.get("args").unwrap();
+        let mut args = vec![];
+        if args_string.to_string() == "[]".to_string() {
+            let args = vec![];
+        } else {
+            let args = vec![args_string.to_string()];
+        }
+        PythonTaskDefinition::new(FilePath::from(script_path), args)
+    }
 }
 
 impl TaskDefinition for PythonTaskDefinition {

--- a/src/task_definition/python_task.rs
+++ b/src/task_definition/python_task.rs
@@ -1,5 +1,5 @@
 use crate::errors::YoshiError;
-use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType, DefinitionArguments};
+use crate::task_definition::{generate_task_definition_id, TaskDefinition, TaskDefinitionType, DefinitionArguments, DefinitionArgumentElement};
 use crate::task_output::TaskOutput;
 use crate::type_definition::{FilePath, TaskId};
 use log::{debug, error, info};
@@ -18,15 +18,29 @@ pub struct PythonTaskDefinition {
 
 impl From<DefinitionArguments> for PythonTaskDefinition {
     fn from(da: DefinitionArguments) -> Self {
-        let script_path = da.params.get("script_path").unwrap();
-        let args_string = da.params.get("args").unwrap();
-        let mut args = vec![];
-        if args_string.to_string() == "[]".to_string() {
-            let args = vec![];
-        } else {
-            let args = vec![args_string.to_string()];
+        let mut script_path = FilePath::new();
+        let mut args: Vec<String> = vec![];
+        if let Some(e) = da.get(&"script_path".to_string()) {
+            match e {
+                DefinitionArgumentElement::Filepath(fp) => {
+                    script_path = fp;
+                },
+                _ => {
+                    panic!("'script_path' for PythonTask must be a Filepath");    
+                }
+            }
         }
-        PythonTaskDefinition::new(FilePath::from(script_path), args)
+        if let Some(e) = da.get(&"args".to_string()) {
+            match e {
+                DefinitionArgumentElement::VecString(vs) => {
+                    args = vs;
+                },
+                _ => {
+                    panic!("'args' for PythonTask must be a VecString");
+                }
+            }
+        }
+        PythonTaskDefinition::new(script_path, args)
     }
 }
 

--- a/src/task_definition/python_task_test.rs
+++ b/src/task_definition/python_task_test.rs
@@ -51,5 +51,5 @@ fn it_can_return_parameters() {
     let params = ptd.get_params();
     let p = script_path.clone().into_string().unwrap();
     assert_eq!(params.get("script_path"), Some(&p));
-    assert_eq!(params.get("args"), Some(&"one two ".to_string()));
+    assert_eq!(params.get("args"), Some(&"[one two]".to_string()));
 }

--- a/src/task_definition/python_task_test.rs
+++ b/src/task_definition/python_task_test.rs
@@ -1,7 +1,9 @@
 use crate::task_definition::python_task::*;
+use crate::task_definition::{generate_task_definition_id, TaskDefinition};
 use crate::test_utils::init_logger;
 use crate::type_definition::FilePath;
 use std::boxed::Box;
+use crate::task_output::TaskOutput;
 use std::fs::{remove_file, File};
 use std::io::prelude::*;
 
@@ -9,11 +11,12 @@ use std::io::prelude::*;
 fn it_can_run_basic_script() {
     init_logger();
 
-    let script_path = FilePath::from("script.py");
+    let script_path = FilePath::from("/tmp/script.py");
     let mut file = File::create(script_path.clone()).unwrap();
     file.write_all(b"import sys; a = sys.argv[1]; print('all good {}'.format(a))")
         .unwrap();
     let args = vec!["one".to_string()];
+    
     let ptd = PythonTaskDefinition {
         task_def_id: generate_task_definition_id(),
         script_path: Box::new(script_path.clone()),

--- a/src/task_definition/python_task_test.rs
+++ b/src/task_definition/python_task_test.rs
@@ -1,9 +1,9 @@
 use crate::task_definition::python_task::*;
 use crate::task_definition::{generate_task_definition_id, TaskDefinition};
+use crate::task_output::TaskOutput;
 use crate::test_utils::init_logger;
 use crate::type_definition::FilePath;
 use std::boxed::Box;
-use crate::task_output::TaskOutput;
 use std::fs::{remove_file, File};
 use std::io::prelude::*;
 
@@ -16,7 +16,7 @@ fn it_can_run_basic_script() {
     file.write_all(b"import sys; a = sys.argv[1]; print('all good {}'.format(a))")
         .unwrap();
     let args = vec!["one".to_string()];
-    
+
     let ptd = PythonTaskDefinition {
         task_def_id: generate_task_definition_id(),
         script_path: Box::new(script_path.clone()),

--- a/src/task_definition/task_def.rs
+++ b/src/task_definition/task_def.rs
@@ -1,7 +1,7 @@
 use crate::errors::YoshiError;
+use crate::task_definition::TaskDefinitionType;
 use crate::task_output::TaskOutput;
 use crate::type_definition::TaskId;
-use crate::task_definition::{TaskDefinitionType};
 use dyn_clone::DynClone;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -16,7 +16,7 @@ pub trait TaskDefinition: DynClone + Debug {
     /// Execute the action defined
     fn run(&self) -> Result<TaskOutput, YoshiError>;
     /// Return a view of the parameters that are going to be used
-    fn get_params(&self) -> HashMap<String, String>;  // todo: change to DefinitionArguments
+    fn get_params(&self) -> HashMap<String, String>; // todo: change to DefinitionArguments
 }
 
 /// Generate a random (99.99% unique) task id

--- a/src/task_definition/task_def.rs
+++ b/src/task_definition/task_def.rs
@@ -1,7 +1,7 @@
 use crate::errors::YoshiError;
 use crate::task_output::TaskOutput;
 use crate::type_definition::TaskId;
-use crate::task_definition::{TaskDefinitionType, DefinitionArguments};
+use crate::task_definition::{TaskDefinitionType};
 use dyn_clone::DynClone;
 use std::collections::HashMap;
 use std::fmt::Debug;

--- a/src/task_definition/task_def.rs
+++ b/src/task_definition/task_def.rs
@@ -1,27 +1,10 @@
 use crate::errors::YoshiError;
 use crate::task_output::TaskOutput;
 use crate::type_definition::TaskId;
+use crate::task_definition::TaskDefinitionType;
 use dyn_clone::DynClone;
 use std::collections::HashMap;
 use std::fmt::Debug;
-
-/// Enum identifying the variant of Definition
-#[derive(Debug, PartialEq)]
-pub enum TaskDefinitionType {
-    Bash,
-    Python,
-    Dummy,
-}
-
-/// Given a string, return an enum that link to a definition variant
-pub fn string_to_definition_type(def_name: String) -> Option<TaskDefinitionType> {
-    match def_name.as_str() {
-        "python_task_definition" => Some(TaskDefinitionType::Python),
-        "bash_task_definition" => Some(TaskDefinitionType::Bash),
-        "dummy_task_definition" => Some(TaskDefinitionType::Dummy),
-        _ => None,
-    }
-}
 
 /// Trait that define a task that can be started
 /// basically what's to be done

--- a/src/task_definition/task_def.rs
+++ b/src/task_definition/task_def.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 
 /// Trait that define a task that can be started
 /// basically what's to be done
-pub trait TaskDefinition: DynClone + From<DefinitionArguments> + Debug {
+pub trait TaskDefinition: DynClone + Debug {
     /// Return a unique id for the definition (instance)
     fn task_definition_id(&self) -> TaskId;
     /// Return an enum to identify the kind of definition

--- a/src/task_definition/task_def.rs
+++ b/src/task_definition/task_def.rs
@@ -1,14 +1,14 @@
 use crate::errors::YoshiError;
 use crate::task_output::TaskOutput;
 use crate::type_definition::TaskId;
-use crate::task_definition::TaskDefinitionType;
+use crate::task_definition::{TaskDefinitionType, DefinitionArguments};
 use dyn_clone::DynClone;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
 /// Trait that define a task that can be started
 /// basically what's to be done
-pub trait TaskDefinition: DynClone + Debug {
+pub trait TaskDefinition: DynClone + From<DefinitionArguments> + Debug {
     /// Return a unique id for the definition (instance)
     fn task_definition_id(&self) -> TaskId;
     /// Return an enum to identify the kind of definition
@@ -16,7 +16,7 @@ pub trait TaskDefinition: DynClone + Debug {
     /// Execute the action defined
     fn run(&self) -> Result<TaskOutput, YoshiError>;
     /// Return a view of the parameters that are going to be used
-    fn get_params(&self) -> HashMap<String, String>;
+    fn get_params(&self) -> HashMap<String, String>;  // todo: change to DefinitionArguments
 }
 
 /// Generate a random (99.99% unique) task id

--- a/src/task_node.rs
+++ b/src/task_node.rs
@@ -67,7 +67,7 @@ impl PartialEq for TaskNode {
             (None, None) => comp_instance = true,
             _ => comp_instance = false,
         }
-        if comp_instance == false {
+        if !comp_instance {
             return false;
         }
         if self.id_runner != other.id_runner {

--- a/src/task_node_test.rs
+++ b/src/task_node_test.rs
@@ -1,5 +1,5 @@
-use crate::runners::{FakeTaskRunner, TaskRunner, TaskRunnerType};
-use crate::task_definition::{generate_task_definition_id, BashTaskDefinition};
+use crate::runners::TaskRunnerType;
+use crate::task_definition::BashTaskDefinition;
 use crate::task_instance::{TaskInstance, TaskStatus};
 use crate::task_node::TaskNode;
 use crate::task_output::TaskOutput;


### PR DESCRIPTION
We want to create new TaskDefinition by passing the type of definitions to create and all the arguments to pass it
For that, we add DefinitionArguments that contains DefinitionArgumentElement. DA stores all the arguments we want to pass to task definition to instanciate them. 
For that, we made our TaskDefinition implement a From<DefinitionArguments>. That way, it's them who know how to instanciate themselves. We just have to pass the DA
And then, with create_new_definition, we can pass the TaskDefinitionType and a filled DefinitionArguments and it's going to return the TaskDefinition we desire