### PR TITLE
Feature/using definition factory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yoshi"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["gnonpi <legnonpi@gmail.com>"]
 edition = "2018"
 description = "Build complex pipelines of batch jobs - inspired by Python's Luigi"

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -2,9 +2,9 @@ use crate::dag_checker::{check_contains_cycle, find_source_nodes};
 use crate::errors::YoshiError;
 use crate::runners::MessageFromRunner::{Done, Failure};
 use crate::runners::TaskRunnerFactory;
+use crate::task_definition::create_new_definition;
 use crate::task_node::TaskNode;
 use crate::type_definition::NodeId;
-use crate::task_definition::create_new_definition;
 use crossbeam_channel::TryRecvError;
 use log::{debug, info};
 use petgraph::graphmap::DiGraphMap;
@@ -165,7 +165,10 @@ impl Dag {
 
                     let mut node_runner = TaskRunnerFactory::new_runner(&(*node).id_runner);
                     let (_, recv_from_runner) = node_runner.get_channels();
-                    let task_definition = create_new_definition(&node.definition_type, node.definition_arguments.clone());
+                    let task_definition = create_new_definition(
+                        &node.definition_type,
+                        node.definition_arguments.clone(),
+                    );
                     node_runner
                         .start_task(id_node, &(*task_definition))
                         .unwrap();

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -4,6 +4,7 @@ use crate::runners::MessageFromRunner::{Done, Failure};
 use crate::runners::TaskRunnerFactory;
 use crate::task_node::TaskNode;
 use crate::type_definition::NodeId;
+use crate::task_definition::create_new_definition;
 use crossbeam_channel::TryRecvError;
 use log::{debug, info};
 use petgraph::graphmap::DiGraphMap;
@@ -164,8 +165,9 @@ impl Dag {
 
                     let mut node_runner = TaskRunnerFactory::new_runner(&(*node).id_runner);
                     let (_, recv_from_runner) = node_runner.get_channels();
+                    let task_definition = create_new_definition(&node.definition_type, node.definition_arguments.clone());
                     node_runner
-                        .start_task(id_node, &(*node.definition))
+                        .start_task(id_node, &(*task_definition))
                         .unwrap();
 
                     // todo: replace with true spawning&waiting

--- a/src/dag_checker_test.rs
+++ b/src/dag_checker_test.rs
@@ -1,6 +1,6 @@
 use crate::dag::Dag;
 use crate::dag_checker::{check_contains_cycle, find_sink_nodes, find_source_nodes};
-use crate::task_definition::{TaskDefinitionType, DefinitionArguments};
+use crate::task_definition::{DefinitionArguments, TaskDefinitionType};
 use crate::task_node::TaskNode;
 use crate::type_definition::RunnerId;
 
@@ -31,13 +31,21 @@ fn it_can_find_sources_nodes() {
     let res = find_source_nodes(&dag);
     assert_eq!(res.len(), 0);
 
-    let first_node = TaskNode::new(TaskDefinitionType::Dummy, DefinitionArguments::new(), RunnerId::Fake);
+    let first_node = TaskNode::new(
+        TaskDefinitionType::Dummy,
+        DefinitionArguments::new(),
+        RunnerId::Fake,
+    );
     let first_id = first_node.id_node.clone();
     dag.add_task(first_node, None, None);
     let res = find_source_nodes(&dag);
     assert_eq!(res, vec![first_id]);
 
-    let second_node = TaskNode::new(TaskDefinitionType::Dummy, DefinitionArguments::new(), RunnerId::Fake);
+    let second_node = TaskNode::new(
+        TaskDefinitionType::Dummy,
+        DefinitionArguments::new(),
+        RunnerId::Fake,
+    );
     dag.add_task(second_node, Some(vec![&first_id]), None);
     let res = find_source_nodes(&dag);
     assert_eq!(res, vec![first_id]);
@@ -49,13 +57,21 @@ fn it_can_find_sink_nodes() {
     let res = find_source_nodes(&dag);
     assert_eq!(res.len(), 0);
 
-    let first_node = TaskNode::new(TaskDefinitionType::Dummy, DefinitionArguments::new(), RunnerId::Fake);
+    let first_node = TaskNode::new(
+        TaskDefinitionType::Dummy,
+        DefinitionArguments::new(),
+        RunnerId::Fake,
+    );
     let first_id = first_node.id_node.clone();
     dag.add_task(first_node, None, None);
     let res = find_sink_nodes(&dag);
     assert_eq!(res, vec![first_id]);
 
-    let second_node = TaskNode::new(TaskDefinitionType::Dummy, DefinitionArguments::new(), RunnerId::Fake);
+    let second_node = TaskNode::new(
+        TaskDefinitionType::Dummy,
+        DefinitionArguments::new(),
+        RunnerId::Fake,
+    );
     let second_id = second_node.id_node.clone();
     dag.add_task(second_node, Some(vec![&first_id]), None);
     let res = find_sink_nodes(&dag);

--- a/src/dag_checker_test.rs
+++ b/src/dag_checker_test.rs
@@ -1,6 +1,6 @@
 use crate::dag::Dag;
 use crate::dag_checker::{check_contains_cycle, find_sink_nodes, find_source_nodes};
-use crate::task_definition::DummyTaskDefinition;
+use crate::task_definition::{TaskDefinitionType, DefinitionArguments};
 use crate::task_node::TaskNode;
 use crate::type_definition::RunnerId;
 
@@ -31,15 +31,13 @@ fn it_can_find_sources_nodes() {
     let res = find_source_nodes(&dag);
     assert_eq!(res.len(), 0);
 
-    let t_def = DummyTaskDefinition {};
-    let first_node = TaskNode::new(Box::new(t_def), RunnerId::Fake);
+    let first_node = TaskNode::new(TaskDefinitionType::Dummy, DefinitionArguments::new(), RunnerId::Fake);
     let first_id = first_node.id_node.clone();
     dag.add_task(first_node, None, None);
     let res = find_source_nodes(&dag);
     assert_eq!(res, vec![first_id]);
 
-    let t_def = DummyTaskDefinition {};
-    let second_node = TaskNode::new(Box::new(t_def), RunnerId::Fake);
+    let second_node = TaskNode::new(TaskDefinitionType::Dummy, DefinitionArguments::new(), RunnerId::Fake);
     dag.add_task(second_node, Some(vec![&first_id]), None);
     let res = find_source_nodes(&dag);
     assert_eq!(res, vec![first_id]);
@@ -51,15 +49,13 @@ fn it_can_find_sink_nodes() {
     let res = find_source_nodes(&dag);
     assert_eq!(res.len(), 0);
 
-    let t_def = DummyTaskDefinition {};
-    let first_node = TaskNode::new(Box::new(t_def), RunnerId::Fake);
+    let first_node = TaskNode::new(TaskDefinitionType::Dummy, DefinitionArguments::new(), RunnerId::Fake);
     let first_id = first_node.id_node.clone();
     dag.add_task(first_node, None, None);
     let res = find_sink_nodes(&dag);
     assert_eq!(res, vec![first_id]);
 
-    let t_def = DummyTaskDefinition {};
-    let second_node = TaskNode::new(Box::new(t_def), RunnerId::Fake);
+    let second_node = TaskNode::new(TaskDefinitionType::Dummy, DefinitionArguments::new(), RunnerId::Fake);
     let second_id = second_node.id_node.clone();
     dag.add_task(second_node, Some(vec![&first_id]), None);
     let res = find_sink_nodes(&dag);

--- a/src/dag_parsing/dag_config.rs
+++ b/src/dag_parsing/dag_config.rs
@@ -2,10 +2,7 @@ use crate::dag::Dag;
 use crate::dag_parsing::{DagConfigParser, DagParsingError, YamlDagConfigParser};
 use crate::runners::string_to_runner_type;
 use crate::task_definition::{
-    string_to_definition_type, 
-    TaskDefinition, 
-    TaskDefinitionType,
-    DefinitionArguments
+    string_to_definition_type, DefinitionArguments, TaskDefinition, TaskDefinitionType,
 };
 use crate::task_node::TaskNode;
 use crate::type_definition::{FilePath, NodeId};

--- a/src/dag_parsing/dag_config.rs
+++ b/src/dag_parsing/dag_config.rs
@@ -1,10 +1,7 @@
 use crate::dag::Dag;
 use crate::dag_parsing::{DagConfigParser, DagParsingError, YamlDagConfigParser};
 use crate::runners::string_to_runner_type;
-use crate::task_definition::{
-    string_to_definition_type, BashTaskDefinition, DummyTaskDefinition, PythonTaskDefinition,
-    TaskDefinition, TaskDefinitionType,
-};
+use crate::task_definition::{string_to_definition_type, BashTaskDefinition, DummyTaskDefinition, PythonTaskDefinition, TaskDefinition, TaskDefinitionType, DefinitionArguments};
 use crate::task_node::TaskNode;
 use crate::type_definition::{FilePath, NodeId};
 use log::{debug, error, info};
@@ -105,32 +102,14 @@ impl From<DagConfig> for Dag {
             let def_type = string_to_definition_type(def_cfg.definition_type.clone()).unwrap();
             let runner_type = string_to_runner_type(runner_cfg.runner_type.clone()).unwrap();
 
-            let definition: Box<dyn TaskDefinition>;
-            match def_type {
-                TaskDefinitionType::Bash => {
-                    let commands = def_cfg.params.get("command").unwrap();
-                    definition = Box::new(BashTaskDefinition::new(vec![commands.to_string()]));
-                }
-                TaskDefinitionType::Python => {
-                    let script_path = def_cfg.params.get("script_path").unwrap();
-                    let args_string = def_cfg.params.get("args").unwrap();
-                    let mut args: Vec<String> = vec![];
-                    if args_string.to_string() == "[]".to_string() {
-                        let args: Vec<String> = vec![];
-                    } else {
-                        let args = vec![args_string.to_string()];
-                    }
-                    definition =
-                        Box::new(PythonTaskDefinition::new(FilePath::from(script_path), args));
-                }
-                TaskDefinitionType::Dummy => {
-                    let dummy = DummyTaskDefinition {};
-                    definition = Box::new(dummy);
-                }
+            // transforming def params to definition arguments
+            let mut da = DefinitionArguments::new();
+            for (key, value) in def_cfg.params.iter() {
+                da.set(key, value.to_string());
             }
 
             // creating node
-            let mut node = TaskNode::new(definition, runner_type);
+            let mut node = TaskNode::new(def_type, da, runner_type);
             node.set_label(node_cfg_id);
             node_cfg_id_to_node_id.insert(node_cfg_id.to_string(), node.id_node);
             dag.add_task(node, None, None);

--- a/src/dag_parsing/dag_config.rs
+++ b/src/dag_parsing/dag_config.rs
@@ -2,8 +2,10 @@ use crate::dag::Dag;
 use crate::dag_parsing::{DagConfigParser, DagParsingError, YamlDagConfigParser};
 use crate::runners::string_to_runner_type;
 use crate::task_definition::{
-    string_to_definition_type, BashTaskDefinition, DefinitionArguments, DummyTaskDefinition,
-    PythonTaskDefinition, TaskDefinition, TaskDefinitionType,
+    string_to_definition_type, 
+    TaskDefinition, 
+    TaskDefinitionType,
+    DefinitionArguments
 };
 use crate::task_node::TaskNode;
 use crate::type_definition::{FilePath, NodeId};

--- a/src/dag_parsing/dag_config.rs
+++ b/src/dag_parsing/dag_config.rs
@@ -1,7 +1,10 @@
 use crate::dag::Dag;
 use crate::dag_parsing::{DagConfigParser, DagParsingError, YamlDagConfigParser};
 use crate::runners::string_to_runner_type;
-use crate::task_definition::{string_to_definition_type, BashTaskDefinition, DummyTaskDefinition, PythonTaskDefinition, TaskDefinition, TaskDefinitionType, DefinitionArguments};
+use crate::task_definition::{
+    string_to_definition_type, BashTaskDefinition, DefinitionArguments, DummyTaskDefinition,
+    PythonTaskDefinition, TaskDefinition, TaskDefinitionType,
+};
 use crate::task_node::TaskNode;
 use crate::type_definition::{FilePath, NodeId};
 use log::{debug, error, info};

--- a/src/dag_parsing/dag_config_test.rs
+++ b/src/dag_parsing/dag_config_test.rs
@@ -60,30 +60,21 @@ fn it_can_take_config_to_dag() {
 
     // dummy_start
     let dummy_start_node = result_dag.map_nodes.get(dummy_start_id).unwrap();
-    assert_eq!(
-        dummy_start_node.definition_type,
-        TaskDefinitionType::Dummy
-    );
+    assert_eq!(dummy_start_node.definition_type, TaskDefinitionType::Dummy);
     assert_eq!(dummy_start_node.id_runner, TaskRunnerType::LocalBlocking);
     let neighbors_start: Vec<NodeId> = result_dag.graph_nodes.neighbors(*dummy_start_id).collect();
     assert_eq!(neighbors_start, vec![node_a_id.clone(), node_b_id.clone()]);
 
     // dummy end
     let dummy_end_node = result_dag.map_nodes.get(dummy_end_id).unwrap();
-    assert_eq!(
-        dummy_start_node.definition_type,
-        TaskDefinitionType::Dummy
-    );
+    assert_eq!(dummy_start_node.definition_type, TaskDefinitionType::Dummy);
     assert_eq!(dummy_end_node.id_runner, TaskRunnerType::LocalBlocking);
     let neighbors_end: Vec<NodeId> = result_dag.graph_nodes.neighbors(*dummy_end_id).collect();
     assert_eq!(neighbors_end, vec![]);
 
     // nodeA
     let node_a_node = result_dag.map_nodes.get(node_a_id).unwrap();
-    assert_eq!(
-        node_a_node.definition_type,
-        TaskDefinitionType::Python
-    );
+    assert_eq!(node_a_node.definition_type, TaskDefinitionType::Python);
     assert_eq!(node_a_node.id_runner, TaskRunnerType::LocalBlocking);
     let neighbors_a: Vec<NodeId> = result_dag.graph_nodes.neighbors(*node_a_id).collect();
     assert_eq!(neighbors_a, vec![dummy_end_id.clone()]);

--- a/src/dag_parsing/dag_config_test.rs
+++ b/src/dag_parsing/dag_config_test.rs
@@ -55,23 +55,23 @@ fn it_can_take_config_to_dag() {
     //
     let dummy_start_id = map_node_id_to_label.get("dummy_start").unwrap();
     let dummy_end_id = map_node_id_to_label.get("dummy_end").unwrap();
-    let nodeA_id = map_node_id_to_label.get("nodeA").unwrap();
-    let nodeB_id = map_node_id_to_label.get("nodeB").unwrap();
+    let node_a_id = map_node_id_to_label.get("nodeA").unwrap();
+    let node_b_id = map_node_id_to_label.get("nodeB").unwrap();
 
     // dummy_start
     let dummy_start_node = result_dag.map_nodes.get(dummy_start_id).unwrap();
     assert_eq!(
-        dummy_start_node.definition.task_type(),
+        dummy_start_node.definition_type,
         TaskDefinitionType::Dummy
     );
     assert_eq!(dummy_start_node.id_runner, TaskRunnerType::LocalBlocking);
     let neighbors_start: Vec<NodeId> = result_dag.graph_nodes.neighbors(*dummy_start_id).collect();
-    assert_eq!(neighbors_start, vec![nodeA_id.clone(), nodeB_id.clone()]);
+    assert_eq!(neighbors_start, vec![node_a_id.clone(), node_b_id.clone()]);
 
     // dummy end
     let dummy_end_node = result_dag.map_nodes.get(dummy_end_id).unwrap();
     assert_eq!(
-        dummy_end_node.definition.task_type(),
+        dummy_start_node.definition_type,
         TaskDefinitionType::Dummy
     );
     assert_eq!(dummy_end_node.id_runner, TaskRunnerType::LocalBlocking);
@@ -79,13 +79,13 @@ fn it_can_take_config_to_dag() {
     assert_eq!(neighbors_end, vec![]);
 
     // nodeA
-    let nodeA_node = result_dag.map_nodes.get(nodeA_id).unwrap();
+    let node_a_node = result_dag.map_nodes.get(node_a_id).unwrap();
     assert_eq!(
-        nodeA_node.definition.task_type(),
+        node_a_node.definition_type,
         TaskDefinitionType::Python
     );
-    assert_eq!(nodeA_node.id_runner, TaskRunnerType::LocalBlocking);
-    let neighbors_a: Vec<NodeId> = result_dag.graph_nodes.neighbors(*nodeA_id).collect();
+    assert_eq!(node_a_node.id_runner, TaskRunnerType::LocalBlocking);
+    let neighbors_a: Vec<NodeId> = result_dag.graph_nodes.neighbors(*node_a_id).collect();
     assert_eq!(neighbors_a, vec![dummy_end_id.clone()]);
 
     // todo: add nodeB

--- a/src/dag_test.rs
+++ b/src/dag_test.rs
@@ -1,6 +1,8 @@
 use crate::dag::Dag;
 use crate::runners::TaskRunnerType;
-use crate::task_definition::{generate_task_definition_id, TaskDefinitionType, DefinitionArguments, DefinitionArgumentType};
+use crate::task_definition::{
+    generate_task_definition_id, DefinitionArgumentType, DefinitionArguments, TaskDefinitionType,
+};
 use crate::task_node::TaskNode;
 
 fn _produce_task_node() -> TaskNode {

--- a/src/dag_test.rs
+++ b/src/dag_test.rs
@@ -5,7 +5,7 @@ use crate::task_node::TaskNode;
 
 fn _produce_task_node() -> TaskNode {
     let mut da = DefinitionArguments::new();
-    da.set(&"command".to_string(), "[\"echo\", \"'Hello'\"".to_string(), DefinitionArgumentType::VecString);
+    da.set(&"command".to_string(), "[\"echo\", \"'Hello'\"".to_string());
     TaskNode::new(TaskDefinitionType::Bash, da, TaskRunnerType::Fake)
 }
 

--- a/src/dag_test.rs
+++ b/src/dag_test.rs
@@ -1,11 +1,12 @@
 use crate::dag::Dag;
 use crate::runners::TaskRunnerType;
-use crate::task_definition::{generate_task_definition_id, BashTaskDefinition};
+use crate::task_definition::{generate_task_definition_id, TaskDefinitionType, DefinitionArguments, DefinitionArgumentType};
 use crate::task_node::TaskNode;
 
 fn _produce_task_node() -> TaskNode {
-    let t_def = BashTaskDefinition::new(vec!["echo".to_owned(), "'Hello'".to_owned()]);
-    TaskNode::new(Box::new(t_def), TaskRunnerType::Fake)
+    let mut da = DefinitionArguments::new();
+    da.set(&"command".to_string(), "[\"echo\", \"'Hello'\"".to_string(), DefinitionArgumentType::VecString);
+    TaskNode::new(TaskDefinitionType::Bash, da, TaskRunnerType::Fake)
 }
 
 #[test]

--- a/src/task_definition/bash_task.rs
+++ b/src/task_definition/bash_task.rs
@@ -1,6 +1,6 @@
 use crate::errors::YoshiError;
 use crate::task_definition::{
-    generate_task_definition_id, DefinitionArgumentElement, DefinitionArguments, TaskDefinition,
+    generate_task_definition_id, DefinitionArgumentElement, DefinitionArguments, DefinitionArgumentType, TaskDefinition,
     TaskDefinitionType,
 };
 use crate::task_output::TaskOutput;
@@ -19,7 +19,7 @@ pub struct BashTaskDefinition {
 
 impl From<DefinitionArguments> for BashTaskDefinition {
     fn from(da: DefinitionArguments) -> Self {
-        if let Some(e) = da.get(&"command".to_string()) {
+        if let Some(e) = da.get(&"command".to_string(), DefinitionArgumentType::VecString) {
             match e {
                 DefinitionArgumentElement::VecString(vs) => BashTaskDefinition::new(vs),
                 _ => {

--- a/src/task_definition/bash_task.rs
+++ b/src/task_definition/bash_task.rs
@@ -1,7 +1,7 @@
 use crate::errors::YoshiError;
 use crate::task_definition::{
-    generate_task_definition_id, DefinitionArgumentElement, DefinitionArguments, DefinitionArgumentType, TaskDefinition,
-    TaskDefinitionType,
+    generate_task_definition_id, DefinitionArgumentElement, DefinitionArgumentType,
+    DefinitionArguments, TaskDefinition, TaskDefinitionType,
 };
 use crate::task_output::TaskOutput;
 use crate::type_definition::TaskId;

--- a/src/task_definition/definition_arguments.rs
+++ b/src/task_definition/definition_arguments.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 // todo: review visibility
 /// Identify what type of argument we're saving.
 /// Allow to parse back a string saved
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum DefinitionArgumentType {
     AString, // A-string to differentiate from type
     Filepath,
@@ -25,6 +25,7 @@ pub enum DefinitionArgumentElement {
 }
 
 /// Save the arguments to pass to a definition
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct DefinitionArguments {
     map: HashMap<String, (String, DefinitionArgumentType)>,
 }

--- a/src/task_definition/definition_arguments.rs
+++ b/src/task_definition/definition_arguments.rs
@@ -75,7 +75,11 @@ impl DefinitionArguments {
         self.map.insert(key.to_string(), value);
     }
 
-    pub fn get(&self, key: &String, da_type: DefinitionArgumentType) -> Option<DefinitionArgumentElement> {
+    pub fn get(
+        &self,
+        key: &String,
+        da_type: DefinitionArgumentType,
+    ) -> Option<DefinitionArgumentElement> {
         match self.map.get(key) {
             Some(v) => {
                 let value = v.to_string();

--- a/src/task_definition/definition_arguments.rs
+++ b/src/task_definition/definition_arguments.rs
@@ -27,7 +27,7 @@ pub enum DefinitionArgumentElement {
 /// Save the arguments to pass to a definition
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct DefinitionArguments {
-    map: HashMap<String, (String, DefinitionArgumentType)>,
+    map: HashMap<String, String>,
 }
 
 // todo: temporary, use a library or something more efficient and fail-proff
@@ -71,15 +71,15 @@ impl DefinitionArguments {
         }
     }
 
-    pub fn set(&mut self, key: &String, value: String, da_type: DefinitionArgumentType) {
-        self.map.insert(key.to_string(), (value, da_type));
+    pub fn set(&mut self, key: &String, value: String) {
+        self.map.insert(key.to_string(), value);
     }
 
-    pub fn get(&self, key: &String) -> Option<DefinitionArgumentElement> {
+    pub fn get(&self, key: &String, da_type: DefinitionArgumentType) -> Option<DefinitionArgumentElement> {
         match self.map.get(key) {
-            Some((v, t)) => {
+            Some(v) => {
                 let value = v.to_string();
-                match t {
+                match da_type {
                     DefinitionArgumentType::AString => {
                         Some(DefinitionArgumentElement::AString(value))
                     }

--- a/src/task_definition/definition_arguments_test.rs
+++ b/src/task_definition/definition_arguments_test.rs
@@ -9,9 +9,9 @@ fn test_setting_value() {
     let value = String::from("my-value");
     let da_type = DefinitionArgumentType::AString;
 
-    da.set(&key, value.clone(), da_type);
+    da.set(&key, value.clone());
     assert!(da.map.get(&key).is_some());
-    let returned_value = da.get(&key).unwrap();
+    let returned_value = da.get(&key, da_type).unwrap();
     assert_eq!(returned_value, (DefinitionArgumentElement::AString(value)));
 }
 
@@ -19,7 +19,7 @@ fn test_setting_value() {
 fn test_getting_unknown_key_is_none() {
     let da = DefinitionArguments::new();
     let key = String::from("my-key");
-    let res = da.get(&key);
+    let res = da.get(&key, DefinitionArgumentType::AString);
     assert!(res.is_none());
 }
 
@@ -35,8 +35,8 @@ fn test_getting_converts_to_type() {
     ];
     let da_type = DefinitionArgumentType::VecString;
 
-    da.set(&key, value.clone(), da_type);
-    let res = da.get(&key);
+    da.set(&key, value.clone());
+    let res = da.get(&key, da_type);
     assert!(res.is_some());
     let res_value = res.unwrap();
     assert_eq!(res_value, DefinitionArgumentElement::VecString(expected));

--- a/src/task_definition/definition_factory.rs
+++ b/src/task_definition/definition_factory.rs
@@ -4,7 +4,7 @@ use crate::task_definition::{
 };
 
 /// Enum identifying the variant of Definition
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TaskDefinitionType {
     Bash,
     Python,

--- a/src/task_definition/definition_factory_test.rs
+++ b/src/task_definition/definition_factory_test.rs
@@ -10,7 +10,6 @@ fn it_can_create_bash_def() {
     da.set(
         &"command".to_string(),
         command.clone(),
-        DefinitionArgumentType::VecString,
     );
 
     let b_def = create_new_definition(&TaskDefinitionType::Bash, da);
@@ -30,12 +29,10 @@ fn it_can_create_python_def() {
     da.set(
         &"script_path".to_string(),
         script_path.clone(),
-        DefinitionArgumentType::Filepath,
     );
     da.set(
         &"args".to_string(),
         args.clone(),
-        DefinitionArgumentType::VecString,
     );
 
     let p_def = create_new_definition(&TaskDefinitionType::Python, da);

--- a/src/task_definition/definition_factory_test.rs
+++ b/src/task_definition/definition_factory_test.rs
@@ -7,10 +7,7 @@ use std::collections::HashMap;
 fn it_can_create_bash_def() {
     let mut da = DefinitionArguments::new();
     let command = "[\"echo\", \"'1'\"]".to_string();
-    da.set(
-        &"command".to_string(),
-        command.clone(),
-    );
+    da.set(&"command".to_string(), command.clone());
 
     let b_def = create_new_definition(&TaskDefinitionType::Bash, da);
     assert_eq!(b_def.task_type(), TaskDefinitionType::Bash);
@@ -26,14 +23,8 @@ fn it_can_create_python_def() {
     let mut da = DefinitionArguments::new();
     let script_path = String::from("/tmp/script.py");
     let args = String::from("[\"one\"]");
-    da.set(
-        &"script_path".to_string(),
-        script_path.clone(),
-    );
-    da.set(
-        &"args".to_string(),
-        args.clone(),
-    );
+    da.set(&"script_path".to_string(), script_path.clone());
+    da.set(&"args".to_string(), args.clone());
 
     let p_def = create_new_definition(&TaskDefinitionType::Python, da);
     assert_eq!(p_def.task_type(), TaskDefinitionType::Python);

--- a/src/task_definition/python_task.rs
+++ b/src/task_definition/python_task.rs
@@ -1,6 +1,10 @@
 use crate::errors::YoshiError;
 use crate::task_definition::{
-    generate_task_definition_id, DefinitionArgumentElement, DefinitionArguments, TaskDefinition,
+    generate_task_definition_id,
+    DefinitionArgumentElement,
+    DefinitionArguments,
+    DefinitionArgumentType,
+    TaskDefinition,
     TaskDefinitionType,
 };
 use crate::task_output::TaskOutput;
@@ -23,7 +27,7 @@ impl From<DefinitionArguments> for PythonTaskDefinition {
     fn from(da: DefinitionArguments) -> Self {
         let mut script_path = FilePath::new();
         let mut args: Vec<String> = vec![];
-        if let Some(e) = da.get(&"script_path".to_string()) {
+        if let Some(e) = da.get(&"script_path".to_string(), DefinitionArgumentType::Filepath) {
             match e {
                 DefinitionArgumentElement::Filepath(fp) => {
                     script_path = fp;
@@ -35,7 +39,7 @@ impl From<DefinitionArguments> for PythonTaskDefinition {
         } else {
             panic!("Not found mandatory argument 'script_path' for PythonTask");
         }
-        if let Some(e) = da.get(&"args".to_string()) {
+        if let Some(e) = da.get(&"args".to_string(), DefinitionArgumentType::VecString) {
             match e {
                 DefinitionArgumentElement::VecString(vs) => {
                     args = vs;

--- a/src/task_definition/python_task.rs
+++ b/src/task_definition/python_task.rs
@@ -1,11 +1,7 @@
 use crate::errors::YoshiError;
 use crate::task_definition::{
-    generate_task_definition_id,
-    DefinitionArgumentElement,
-    DefinitionArguments,
-    DefinitionArgumentType,
-    TaskDefinition,
-    TaskDefinitionType,
+    generate_task_definition_id, DefinitionArgumentElement, DefinitionArgumentType,
+    DefinitionArguments, TaskDefinition, TaskDefinitionType,
 };
 use crate::task_output::TaskOutput;
 use crate::type_definition::{FilePath, TaskId};

--- a/src/task_instance.rs
+++ b/src/task_instance.rs
@@ -16,6 +16,7 @@ pub enum TaskStatus {
 #[derive(Clone, PartialEq, Debug)]
 pub struct TaskInstance {
     pub id_node: NodeId,
+    // todo: we have to link id to actual data
     pub id_task_definition: TaskId,
     pub id_task_runner: RunnerId,
     pub date_started: DateTimeUtc,

--- a/src/task_node.rs
+++ b/src/task_node.rs
@@ -1,4 +1,4 @@
-use crate::task_definition::TaskDefinition;
+use crate::task_definition::{TaskDefinitionType, DefinitionArguments};
 use crate::task_instance::{TaskInstance, TaskStatus};
 use crate::task_output::TaskOutput;
 use crate::type_definition::{NodeId, RunnerId};
@@ -11,23 +11,25 @@ use log::debug;
 pub struct TaskNode {
     pub id_node: NodeId,
     pub label: Option<String>,
-    pub definition: Box<dyn TaskDefinition>,
+    pub definition_type: TaskDefinitionType,
+    pub definition_arguments: DefinitionArguments,
     pub instance: Option<TaskInstance>,
     pub id_runner: RunnerId,
 }
 
 impl TaskNode {
     /// Create a new node
-    pub fn new(definition: Box<dyn TaskDefinition>, id_runner: RunnerId) -> Self {
+    pub fn new(definition_type: TaskDefinitionType, definition_arguments: DefinitionArguments, id_runner: RunnerId) -> Self {
         debug!(
             "Creating task node {:?}-{:?}",
-            definition.task_type(),
+            definition_type.clone(),
             id_runner
         );
         TaskNode {
             id_node: NodeId::new_v4(),
             label: None,
-            definition,
+            definition_type,
+            definition_arguments,
             instance: None,
             id_runner,
         }
@@ -73,11 +75,10 @@ impl PartialEq for TaskNode {
         if self.id_runner != other.id_runner {
             return false;
         }
-        // todo: not the best thing but it'll have to do
-        // i tried implementing a partialeq on taskdefinition
-        // but it made problems about
-        // trait into objects, not sized, not the right types
-        self.definition.get_params() == other.definition.get_params()
+        if self.definition_type != other.definition_type {
+            return false;
+        }
+        return self.definition_arguments == other.definition_arguments
     }
 }
 

--- a/src/task_node.rs
+++ b/src/task_node.rs
@@ -1,4 +1,4 @@
-use crate::task_definition::{TaskDefinitionType, DefinitionArguments};
+use crate::task_definition::{DefinitionArguments, TaskDefinitionType};
 use crate::task_instance::{TaskInstance, TaskStatus};
 use crate::task_output::TaskOutput;
 use crate::type_definition::{NodeId, RunnerId};
@@ -19,7 +19,11 @@ pub struct TaskNode {
 
 impl TaskNode {
     /// Create a new node
-    pub fn new(definition_type: TaskDefinitionType, definition_arguments: DefinitionArguments, id_runner: RunnerId) -> Self {
+    pub fn new(
+        definition_type: TaskDefinitionType,
+        definition_arguments: DefinitionArguments,
+        id_runner: RunnerId,
+    ) -> Self {
         debug!(
             "Creating task node {:?}-{:?}",
             definition_type.clone(),
@@ -78,7 +82,7 @@ impl PartialEq for TaskNode {
         if self.definition_type != other.definition_type {
             return false;
         }
-        return self.definition_arguments == other.definition_arguments
+        return self.definition_arguments == other.definition_arguments;
     }
 }
 

--- a/src/task_node_test.rs
+++ b/src/task_node_test.rs
@@ -1,19 +1,22 @@
 use crate::runners::TaskRunnerType;
-use crate::task_definition::BashTaskDefinition;
+use crate::task_definition::{TaskDefinitionType, DefinitionArguments, DefinitionArgumentType};
 use crate::task_instance::{TaskInstance, TaskStatus};
 use crate::task_node::TaskNode;
 use crate::task_output::TaskOutput;
+use crate::type_definition::TaskId;
 use chrono::prelude::*;
 
 fn _produce_task_node() -> TaskNode {
-    let t_def = BashTaskDefinition::new(vec!["echo".to_owned(), "'Hello'".to_owned()]);
-    TaskNode::new(Box::new(t_def), TaskRunnerType::Fake)
+    let mut da = DefinitionArguments::new();
+    da.set(&"command".to_string(), "[\"echo\", \"'Hello'\"".to_string(), DefinitionArgumentType::VecString);
+    TaskNode::new(TaskDefinitionType::Bash, da, TaskRunnerType::Fake)
 }
 
 #[test]
 fn it_can_create_new_node() {
-    let t_def = BashTaskDefinition::new(vec!["echo".to_owned(), "'Hello'".to_owned()]);
-    let new_node = TaskNode::new(Box::new(t_def), TaskRunnerType::Fake);
+    let mut da = DefinitionArguments::new();
+    da.set(&"command".to_string(), "[\"echo\", \"'Hello'\"".to_string(), DefinitionArgumentType::VecString);
+    let new_node = TaskNode::new(TaskDefinitionType::Bash, da, TaskRunnerType::Fake);
     assert!(new_node.instance.is_none());
     assert_eq!(new_node.id_runner, TaskRunnerType::Fake);
 }
@@ -25,7 +28,7 @@ fn it_says_complete_after_success() {
 
     let instance = TaskInstance {
         id_node: node.id_node.clone(),
-        id_task_definition: node.definition.task_definition_id().clone(),
+        id_task_definition: TaskId::new_v4(),
         id_task_runner: node.id_runner,
         date_started: Utc::now(),
         date_finished: Utc::now(),

--- a/src/task_node_test.rs
+++ b/src/task_node_test.rs
@@ -8,14 +8,14 @@ use chrono::prelude::*;
 
 fn _produce_task_node() -> TaskNode {
     let mut da = DefinitionArguments::new();
-    da.set(&"command".to_string(), "[\"echo\", \"'Hello'\"".to_string(), DefinitionArgumentType::VecString);
+    da.set(&"command".to_string(), "[\"echo\", \"'Hello'\"".to_string());
     TaskNode::new(TaskDefinitionType::Bash, da, TaskRunnerType::Fake)
 }
 
 #[test]
 fn it_can_create_new_node() {
     let mut da = DefinitionArguments::new();
-    da.set(&"command".to_string(), "[\"echo\", \"'Hello'\"".to_string(), DefinitionArgumentType::VecString);
+    da.set(&"command".to_string(), "[\"echo\", \"'Hello'\"".to_string());
     let new_node = TaskNode::new(TaskDefinitionType::Bash, da, TaskRunnerType::Fake);
     assert!(new_node.instance.is_none());
     assert_eq!(new_node.id_runner, TaskRunnerType::Fake);

--- a/src/task_node_test.rs
+++ b/src/task_node_test.rs
@@ -1,5 +1,5 @@
 use crate::runners::TaskRunnerType;
-use crate::task_definition::{TaskDefinitionType, DefinitionArguments, DefinitionArgumentType};
+use crate::task_definition::{DefinitionArgumentType, DefinitionArguments, TaskDefinitionType};
 use crate::task_instance::{TaskInstance, TaskStatus};
 use crate::task_node::TaskNode;
 use crate::task_output::TaskOutput;

--- a/tests/basic_flow.rs
+++ b/tests/basic_flow.rs
@@ -3,7 +3,7 @@ use std::fs::{remove_file, File};
 use std::io::Write;
 use yoshi::dag::Dag;
 use yoshi::runners::{LocalTaskRunner, TaskRunner};
-use yoshi::task_definition::{BashTaskDefinition, PythonTaskDefinition, TaskDefinition};
+use yoshi::task_definition::{TaskDefinitionType, DefinitionArguments, DefinitionArgumentType};
 use yoshi::task_instance::TaskStatus;
 use yoshi::task_node::TaskNode;
 use yoshi::task_output::TaskOutput;
@@ -21,16 +21,19 @@ fn can_mount_simple_dag() {
     // todo: replace with include_string macro
     file.write_all(include_str!("python_script").as_bytes())
         .unwrap();
-    let python_def = PythonTaskDefinition::new(script_path.clone(), vec!["ok".to_owned()]);
+    // Create python arguments
+    let mut da_py = DefinitionArguments::new();
+    da_py.set(&String::from("script_path"), "script.py".to_string(), DefinitionArgumentType::Filepath);
+    da_py.set(&String::from("args"), "[\"ok\"]".to_string(), DefinitionArgumentType::VecString);
 
-    // Create bash task
-    let bash_command = vec!["cat".to_owned(), "/tmp/hello".to_owned()];
-    let bash_def = BashTaskDefinition::new(bash_command);
+    // Create bash arguments
+    let mut da_ba = DefinitionArguments::new();
+    da_ba.set(&String::from("command"), "[\"cat\", \"/tmp/hello\"]".to_string(), DefinitionArgumentType::VecString);
 
     // Create a Dag
     let local_id_runner = LocalTaskRunner::new().get_runner_id();
-    let python_node = TaskNode::new(Box::new(python_def.clone()), local_id_runner);
-    let bash_node = TaskNode::new(Box::new(bash_def.clone()), local_id_runner);
+    let python_node = TaskNode::new(TaskDefinitionType::Python, da_py, local_id_runner);
+    let bash_node = TaskNode::new(TaskDefinitionType::Bash, da_ba, local_id_runner);
     let python_node_id = python_node.id_node.clone();
     let bash_node_id = bash_node.id_node.clone();
     let mut dag = Dag::new();
@@ -56,10 +59,11 @@ fn can_mount_simple_dag() {
         .unwrap()
         .clone();
     assert_eq!(python_task_instance.id_node, python_node_id);
-    assert_eq!(
-        python_task_instance.id_task_definition,
-        python_def.task_definition_id()
-    );
+    // TaskDefinition are now created on the fly
+    // assert_eq!(
+    //     python_task_instance.id_task_definition,
+    //     python_def.task_definition_id()
+    // );
     assert_eq!(python_task_instance.id_task_runner, python_node.id_runner);
     assert!(python_task_instance.date_started > date_before_run);
     assert!(python_task_instance.date_started < date_after_run);
@@ -82,10 +86,7 @@ fn can_mount_simple_dag() {
         .unwrap()
         .clone();
     assert_eq!(bash_task_instance.id_node, bash_node_id);
-    assert_eq!(
-        bash_task_instance.id_task_definition,
-        bash_def.task_definition_id()
-    );
+    // TaskDefinition are now created on the fly
     assert_eq!(bash_task_instance.id_task_runner, bash_node.id_runner);
     assert!(bash_task_instance.date_started > date_before_run);
     assert!(bash_task_instance.date_started < date_after_run);

--- a/tests/basic_flow.rs
+++ b/tests/basic_flow.rs
@@ -23,12 +23,12 @@ fn can_mount_simple_dag() {
         .unwrap();
     // Create python arguments
     let mut da_py = DefinitionArguments::new();
-    da_py.set(&String::from("script_path"), "script.py".to_string(), DefinitionArgumentType::Filepath);
-    da_py.set(&String::from("args"), "[\"ok\"]".to_string(), DefinitionArgumentType::VecString);
+    da_py.set(&String::from("script_path"), "script.py".to_string());
+    da_py.set(&String::from("args"), "[\"ok\"]".to_string());
 
     // Create bash arguments
     let mut da_ba = DefinitionArguments::new();
-    da_ba.set(&String::from("command"), "[\"cat\", \"/tmp/hello\"]".to_string(), DefinitionArgumentType::VecString);
+    da_ba.set(&String::from("command"), "[\"cat\", \"/tmp/hello\"]".to_string());
 
     // Create a Dag
     let local_id_runner = LocalTaskRunner::new().get_runner_id();

--- a/tests/basic_flow.rs
+++ b/tests/basic_flow.rs
@@ -3,7 +3,7 @@ use std::fs::{remove_file, File};
 use std::io::Write;
 use yoshi::dag::Dag;
 use yoshi::runners::{LocalTaskRunner, TaskRunner};
-use yoshi::task_definition::{TaskDefinitionType, DefinitionArguments, DefinitionArgumentType};
+use yoshi::task_definition::{DefinitionArgumentType, DefinitionArguments, TaskDefinitionType};
 use yoshi::task_instance::TaskStatus;
 use yoshi::task_node::TaskNode;
 use yoshi::task_output::TaskOutput;
@@ -28,7 +28,10 @@ fn can_mount_simple_dag() {
 
     // Create bash arguments
     let mut da_ba = DefinitionArguments::new();
-    da_ba.set(&String::from("command"), "[\"cat\", \"/tmp/hello\"]".to_string());
+    da_ba.set(
+        &String::from("command"),
+        "[\"cat\", \"/tmp/hello\"]".to_string(),
+    );
 
     // Create a Dag
     let local_id_runner = LocalTaskRunner::new().get_runner_id();


### PR DESCRIPTION
Now that we have a reliable way of producing TaskDefinition, we can using it in other places.
So when we create a TaskNode, we only have to pass the definition type and the arguments. The proper taskdefinition is created when the node is trying to run in the dag. That means, we don't have a unique task_id until we try running the taskdefinition (runtime) which i find more interesting.
It's also easier to compare nodes or definitions